### PR TITLE
Platform-agnostic event loop interruption

### DIFF
--- a/ggsql-jupyter/src/kernel.rs
+++ b/ggsql-jupyter/src/kernel.rs
@@ -98,9 +98,6 @@ impl KernelServer {
     pub async fn run(&mut self) -> Result<()> {
         tracing::info!("Starting kernel event loop");
 
-        // Set up signal handler for SIGINT (Ctrl+C)
-        let mut sigint = tokio::signal::unix::signal(tokio::signal::unix::SignalKind::interrupt())?;
-
         loop {
             tokio::select! {
                 msg = self.shell.recv() => {
@@ -122,7 +119,7 @@ impl KernelServer {
                         self.heartbeat.send(msg).await?;
                     }
                 }
-                _ = sigint.recv() => {
+                _ = tokio::signal::ctrl_c() => {
                     tracing::warn!("Received SIGINT, shutting down gracefully");
                     // Send a final idle status before exiting
                     // Note: We don't have a parent message here, so we'll send without one


### PR DESCRIPTION
Hi George,

I couldn't run `cargo build` successfully on windows (but I could use that just fine on WSL).
To my understanding, this was due to unix-only handling of interruptions in some event loop.
This change allows me to use `cargo build` successfully on both windows and WSL.
The `cargo test` fails on windows (not WSL), but this may be a separate problem.

Disclaimer:
This is the first rust code I've even touched, and it was with suggestions from an LLM. Please treat with due scrutiny.