### PR TITLE
Fix CLI bug when there is no `VISUALISE` clause

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -185,6 +185,13 @@ fn cmd_exec(query: String, reader: String, writer: String, output: Option<PathBu
     }
 
     // Parse ggSQL portion
+    if viz_part.len() < 1 {
+        if verbose {
+            eprintln!("The ggSQL portion is empty. No specifications produced.");
+        }
+        return ();
+    }
+
     let parsed = parser::parse_query(&query);
     if let Err(e) = parsed {
         eprintln!("Failed to parse ggSQL portion: {}", e);


### PR DESCRIPTION
This PR aims to fix #20.

However, I had trouble reading the code, so I refactored the `cli.rs` file so that I could read it more easily.
I'll summarise the changes:
* Each command has its own function, instead of housing everything in `main()`. The responsibility of `main()` is now to delegate.
* I've replaced deeply nested `match` logic with flat logic, which solves my readability issue.
* The `ggsql run` command re-uses the implementation of `ggsql exec`, avoiding code duplication.

It now behaves like so:
```bash
 ggsql exec "
 COPY (
     SELECT * FROM (VALUES
         (5.2, 18.5),
     ) AS t(x, y)
 ) TO 'data.csv' (HEADER, DELIMITER ',')
 " --verbose
#>  Executing query:
#> COPY (
#>     SELECT * FROM (VALUES
#>         (5.2, 18.5),
#>     ) AS t(x, y)
#> ) TO 'data.csv' (HEADER, DELIMITER ',')
#> 
#> Reader: duckdb://memory
#> Writer: vegalite
#> 
#> Query split:
#>   SQL portion: 110 chars
#>   ggSQL portion: 0 chars
#> 
#> Query executed successfully!
#> Result shape: (1, 1)
#> Columns: ["Count"]
#> The ggSQL portion is empty. No specifications produced.
```
Disclaimer: I'll reiterate that I have close to no experience with rust. Most of the experience that I do claim, is in preparing this PR. LLMs wrote nothing, but advised on some refactor strategies.