### PR TITLE
Add website scaffold

### DIFF
--- a/doc/.gitignore
+++ b/doc/.gitignore
@@ -1,0 +1,2 @@
+/.quarto/
+**/*.quarto_ipynb

--- a/doc/_quarto.yml
+++ b/doc/_quarto.yml
@@ -1,0 +1,21 @@
+project:
+  type: website
+
+website:
+  title: "ggsql"
+  navbar:
+    left:
+      - href: index.qmd
+        text: Home
+      - examples.qmd
+
+format:
+  html:
+    theme:
+      - morph
+      - brand
+    css: styles.css
+    toc: true
+
+
+

--- a/doc/examples.qmd
+++ b/doc/examples.qmd
@@ -1,0 +1,375 @@
+---
+title: Examples
+keep-ipynb: true # TODO: Why does render on save fail without this?
+---
+
+This document demonstrates various ggSQL features with runnable examples using CSV files.
+
+```{ggsql}
+#| echo: false
+#| output: false
+COPY (
+    SELECT * FROM (VALUES
+        (5.2, 18.5),
+        (8.7, 22.3),
+        (12.3, 28.9),
+        (15.8, 35.2),
+        (19.4, 42.7),
+        (23.1, 38.6),
+        (26.8, 45.1),
+        (30.2, 52.8),
+        (33.9, 48.3),
+        (37.5, 55.9),
+        (41.2, 62.4),
+        (44.8, 58.7),
+        (48.3, 65.2),
+        (52.1, 71.8),
+        (55.7, 68.1),
+        (59.4, 74.6)
+    ) AS t(x, y)
+) TO 'data.csv' (HEADER, DELIMITER ',')
+```
+
+```{ggsql}
+#| echo: false
+#| output: false
+COPY (
+    SELECT * FROM (VALUES
+        ('2023-01-15'::DATE, 1000.0, 'North', 'Electronics', 5),
+        ('2023-02-10'::DATE, 1200.0, 'South', 'Electronics', 8),
+        ('2023-03-05'::DATE, 1400.0, 'East', 'Electronics', 7),
+        ('2023-04-20'::DATE, 1100.0, 'West', 'Electronics', 6),
+        ('2023-05-12'::DATE, 1600.0, 'North', 'Electronics', 9),
+        ('2023-06-08'::DATE, 1800.0, 'South', 'Electronics', 10),
+        ('2023-07-14'::DATE, 2000.0, 'East', 'Electronics', 11),
+        ('2023-08-22'::DATE, 2200.0, 'West', 'Electronics', 12),
+        ('2023-09-18'::DATE, 1900.0, 'North', 'Electronics', 8),
+        ('2023-10-25'::DATE, 2400.0, 'South', 'Electronics', 14),
+        ('2023-11-11'::DATE, 2600.0, 'East', 'Electronics', 15),
+        ('2023-12-05'::DATE, 3000.0, 'West', 'Electronics', 16),
+        ('2023-01-20'::DATE, 800.0, 'North', 'Clothing', 25),
+        ('2023-02-15'::DATE, 900.0, 'South', 'Clothing', 30),
+        ('2023-03-10'::DATE, 1100.0, 'East', 'Clothing', 35),
+        ('2023-04-25'::DATE, 1300.0, 'West', 'Clothing', 38),
+        ('2023-05-18'::DATE, 1500.0, 'North', 'Clothing', 42),
+        ('2023-06-12'::DATE, 1700.0, 'South', 'Clothing', 45),
+        ('2023-07-20'::DATE, 1900.0, 'East', 'Clothing', 48),
+        ('2023-08-28'::DATE, 2100.0, 'West', 'Clothing', 50),
+        ('2023-09-22'::DATE, 2300.0, 'North', 'Clothing', 52),
+        ('2023-10-30'::DATE, 2500.0, 'South', 'Clothing', 55),
+        ('2023-11-15'::DATE, 2700.0, 'East', 'Clothing', 58),
+        ('2023-12-10'::DATE, 2900.0, 'West', 'Clothing', 60),
+        ('2023-01-25'::DATE, 600.0, 'North', 'Furniture', 3),
+        ('2023-02-18'::DATE, 700.0, 'South', 'Furniture', 3),
+        ('2023-03-15'::DATE, 850.0, 'East', 'Furniture', 4),
+        ('2023-04-28'::DATE, 950.0, 'West', 'Furniture', 4),
+        ('2023-05-22'::DATE, 1050.0, 'North', 'Furniture', 5),
+        ('2023-06-16'::DATE, 1150.0, 'South', 'Furniture', 5),
+        ('2023-07-24'::DATE, 1250.0, 'East', 'Furniture', 5),
+        ('2023-08-30'::DATE, 1350.0, 'West', 'Furniture', 6),
+        ('2023-09-26'::DATE, 1450.0, 'North', 'Furniture', 6),
+        ('2023-10-31'::DATE, 1550.0, 'South', 'Furniture', 6),
+        ('2023-11-20'::DATE, 1650.0, 'East', 'Furniture', 7),
+        ('2023-12-15'::DATE, 1750.0, 'West', 'Furniture', 7)
+    ) AS t(sale_date, revenue, region, category, quantity)
+) TO 'sales.csv' (HEADER, DELIMITER ',')
+```
+
+```{ggsql}
+#| echo: false
+#| output: false
+COPY (
+    SELECT * FROM (VALUES
+        ('2023-01-01'::DATE, 100.0),
+        ('2023-01-08'::DATE, 110.0),
+        ('2023-01-15'::DATE, 105.0),
+        ('2023-01-22'::DATE, 115.0),
+        ('2023-01-29'::DATE, 120.0),
+        ('2023-02-05'::DATE, 118.0),
+        ('2023-02-12'::DATE, 125.0),
+        ('2023-02-19'::DATE, 130.0),
+        ('2023-02-26'::DATE, 128.0),
+        ('2023-03-05'::DATE, 135.0),
+        ('2023-03-12'::DATE, 142.0),
+        ('2023-03-19'::DATE, 138.0),
+        ('2023-03-26'::DATE, 145.0),
+        ('2023-04-02'::DATE, 150.0),
+        ('2023-04-09'::DATE, 148.0),
+        ('2023-04-16'::DATE, 155.0),
+        ('2023-04-23'::DATE, 160.0),
+        ('2023-04-30'::DATE, 158.0),
+        ('2023-05-07'::DATE, 165.0),
+        ('2023-05-14'::DATE, 170.0)
+    ) AS t(date, value)
+) TO 'timeseries.csv' (HEADER, DELIMITER ',')
+```
+
+```{ggsql}
+#| echo: false
+#| output: false
+COPY (
+    SELECT * FROM (VALUES
+        ('2023-01-01'::DATE, 45.2, 'Sales'),
+        ('2023-02-01'::DATE, 52.1, 'Sales'),
+        ('2023-03-01'::DATE, 48.7, 'Sales'),
+        ('2023-04-01'::DATE, 58.3, 'Sales'),
+        ('2023-05-01'::DATE, 62.5, 'Sales'),
+        ('2023-06-01'::DATE, 67.8, 'Sales'),
+        ('2023-07-01'::DATE, 71.2, 'Sales'),
+        ('2023-08-01'::DATE, 75.6, 'Sales'),
+        ('2023-09-01'::DATE, 80.1, 'Sales'),
+        ('2023-10-01'::DATE, 85.4, 'Sales'),
+        ('2023-11-01'::DATE, 90.2, 'Sales'),
+        ('2023-12-01'::DATE, 95.8, 'Sales'),
+        ('2023-01-01'::DATE, 120.5, 'Marketing'),
+        ('2023-02-01'::DATE, 135.2, 'Marketing'),
+        ('2023-03-01'::DATE, 128.9, 'Marketing'),
+        ('2023-04-01'::DATE, 142.3, 'Marketing'),
+        ('2023-05-01'::DATE, 155.7, 'Marketing'),
+        ('2023-06-01'::DATE, 148.2, 'Marketing'),
+        ('2023-07-01'::DATE, 162.8, 'Marketing'),
+        ('2023-08-01'::DATE, 175.4, 'Marketing'),
+        ('2023-09-01'::DATE, 168.9, 'Marketing'),
+        ('2023-10-01'::DATE, 182.5, 'Marketing'),
+        ('2023-11-01'::DATE, 195.1, 'Marketing'),
+        ('2023-12-01'::DATE, 188.7, 'Marketing'),
+        ('2023-01-01'::DATE, 78.3, 'Support'),
+        ('2023-02-01'::DATE, 82.1, 'Support'),
+        ('2023-03-01'::DATE, 75.6, 'Support'),
+        ('2023-04-01'::DATE, 85.9, 'Support'),
+        ('2023-05-01'::DATE, 92.4, 'Support'),
+        ('2023-06-01'::DATE, 88.7, 'Support'),
+        ('2023-07-01'::DATE, 95.2, 'Support'),
+        ('2023-08-01'::DATE, 101.8, 'Support'),
+        ('2023-09-01'::DATE, 97.5, 'Support'),
+        ('2023-10-01'::DATE, 105.3, 'Support'),
+        ('2023-11-01'::DATE, 112.6, 'Support'),
+        ('2023-12-01'::DATE, 108.9, 'Support')
+    ) AS t(date, value, category)
+) TO 'metrics.csv' (HEADER, DELIMITER ',')
+```
+
+## Basic Visualizations
+
+### Simple Scatter Plot
+
+```{ggsql}
+SELECT x, y FROM 'data.csv'
+VISUALISE x, y
+DRAW point
+```
+
+### Line Chart with Date Scale
+
+```{ggsql}
+SELECT sale_date, revenue FROM 'sales.csv'
+WHERE category = 'Electronics'
+VISUALISE sale_date AS x, revenue AS y
+DRAW line
+SCALE x SETTING type => 'date'
+LABEL title = 'Electronics Revenue Over Time', x = 'Date', y = 'Revenue ($)'
+```
+
+### Bar Chart by Category
+
+```{ggsql}
+SELECT category, SUM(revenue) as total
+FROM 'sales.csv'
+GROUP BY category
+VISUALISE category AS x, total AS y, category AS fill
+DRAW bar
+LABEL title = 'Total Revenue by Category', x = 'Category', y = 'Total Revenue ($)'
+```
+
+### Line chart with multiple lines with same aesthetics
+
+```{ggsql}
+SELECT * FROM 'sales.csv'
+VISUALISE sale_date AS x, revenue AS y
+DRAW line
+    PARTITION BY category
+```
+
+## Multiple Layers
+
+### Line with Points
+
+```{ggsql}
+SELECT date, value FROM 'timeseries.csv'
+VISUALISE date AS x, value AS y
+DRAW line MAPPING 'blue' AS color
+DRAW point MAPPING 'red' AS color SETTING size => 30
+SCALE x SETTING type => 'date'
+LABEL title = 'Time Series with Points', x = 'Date', y = 'Value'
+```
+
+### Colored Lines by Category
+
+```{ggsql}
+SELECT date, value, category FROM 'metrics.csv'
+VISUALISE date AS x, value AS y, category AS color
+DRAW line
+SCALE x SETTING type => 'date'
+LABEL title = 'Metrics by Category', x = 'Date', y = 'Value'
+```
+
+## Faceting
+
+### Facet Wrap by Region
+
+```{ggsql}
+SELECT sale_date, revenue, region FROM 'sales.csv'
+WHERE category = 'Electronics'
+VISUALISE sale_date AS x, revenue AS y
+DRAW line
+SCALE x SETTING type => 'date'
+FACET WRAP region
+LABEL title = 'Electronics Sales by Region', x = 'Date', y = 'Revenue ($)'
+```
+
+### Facet Grid
+
+```{ggsql}
+SELECT
+    DATE_TRUNC('month', sale_date) as month,
+    region,
+    category,
+    SUM(revenue) as total_revenue,
+    SUM(quantity) * 100 as total_quantity_scaled
+FROM 'sales.csv'
+GROUP BY DATE_TRUNC('month', sale_date), region, category
+VISUALISE month AS x
+DRAW line MAPPING total_revenue AS y, 'steelblue' AS color
+DRAW point MAPPING total_revenue AS y, 'darkblue' AS color SETTING size => 30
+DRAW line MAPPING total_quantity_scaled AS y, 'coral' AS color
+DRAW point MAPPING total_quantity_scaled AS y, 'orangered' AS color SETTING size => 30
+SCALE x SETTING type => 'date'
+FACET region BY category
+LABEL title = 'Monthly Revenue and Quantity by Region and Category', x = 'Month', y = 'Value'
+```
+
+## Coordinate Transformations
+
+### Flipped Coordinates (Horizontal Bar Chart)
+
+```{ggsql}
+SELECT region, SUM(revenue) as total
+FROM 'sales.csv'
+GROUP BY region
+ORDER BY total DESC
+VISUALISE region AS x, total AS y, region AS fill
+DRAW bar
+COORD flip
+LABEL title = 'Total Revenue by Region', x = 'Region', y = 'Total Revenue ($)'
+```
+
+### Cartesian with Axis Limits
+
+```{ggsql}
+SELECT x, y FROM 'data.csv'
+VISUALISE x, y
+DRAW point MAPPING 'blue' AS color SETTING size => 4
+COORD cartesian SETTING xlim => [0, 60], ylim => [0, 70]
+LABEL title = 'Scatter Plot with Custom Axis Limits', x = 'X', y = 'Y'
+```
+
+### Pie Chart with Polar Coordinates
+
+```{ggsql}
+SELECT category, SUM(revenue) as total
+FROM 'sales.csv'
+GROUP BY category
+VISUALISE total AS y, category AS fill
+DRAW bar
+COORD polar
+LABEL title = 'Revenue Distribution by Category'
+```
+
+## Layer filtering
+
+### Filter one layer
+
+```{ggsql}
+SELECT date, value FROM 'timeseries.csv'
+VISUALISE date AS x, value AS y
+DRAW line MAPPING 'blue' AS color
+DRAW point MAPPING 'red' AS color, 30 AS size FILTER value < 130
+SCALE x SETTING type => 'date'
+LABEL title = 'Time Series with Points', x = 'Date', y = 'Value'
+```
+
+## Common Table Expressions (CTEs)
+
+### Simple CTE with VISUALISE FROM
+
+```{ggsql}
+WITH monthly_sales AS (
+    SELECT
+        DATE_TRUNC('month', sale_date) as month,
+        SUM(revenue) as total_revenue
+    FROM 'sales.csv'
+    GROUP BY DATE_TRUNC('month', sale_date)
+)
+VISUALISE month AS x, total_revenue AS y FROM monthly_sales
+DRAW line
+DRAW point
+SCALE x SETTING type => 'date'
+LABEL title = 'Monthly Revenue Trends', x = 'Month', y = 'Revenue ($)'
+```
+
+### Multiple CTEs
+
+```{ggsql}
+WITH daily_sales AS (
+    SELECT sale_date, region, SUM(revenue) as revenue
+    FROM 'sales.csv'
+    GROUP BY sale_date, region
+),
+regional_totals AS (
+    SELECT region, SUM(revenue) as total
+    FROM daily_sales
+    GROUP BY region
+)
+VISUALISE region AS x, total AS y, region AS fill FROM regional_totals
+DRAW bar
+COORD flip
+LABEL title = 'Total Revenue by Region', x = 'Region', y = 'Total Revenue ($)'
+```
+
+
+
+## Advanced Examples
+
+### Complete Regional Sales Analysis
+
+```{ggsql}
+SELECT
+    sale_date,
+    region,
+    SUM(quantity) as total_quantity
+FROM 'sales.csv'
+WHERE sale_date >= '2023-01-01'
+GROUP BY sale_date, region
+ORDER BY sale_date
+VISUALISE sale_date AS x, total_quantity AS y, region AS color
+DRAW line
+DRAW point
+SCALE x SETTING type => 'date'
+FACET WRAP region
+LABEL title = 'Sales Trends by Region', x = 'Date', y = 'Total Quantity'
+```
+
+### Multi-Category Analysis
+
+```{ggsql}
+SELECT
+    category,
+    region,
+    SUM(revenue) as total_revenue
+FROM 'sales.csv'
+GROUP BY category, region
+VISUALISE category AS x, total_revenue AS y, region AS fill
+DRAW bar
+LABEL title = 'Revenue by Category and Region', x = 'Category', y = 'Revenue ($)'
+```
+

--- a/doc/index.qmd
+++ b/doc/index.qmd
@@ -1,0 +1,296 @@
+---
+title: "ggsql - SQL Visualization Grammar"
+---
+
+A SQL extension for declarative data visualization based on the Grammar of Graphics.
+
+ggSQL allows you to write queries that combine SQL data retrieval with visualization specifications in a single, composable syntax.
+
+## Example
+
+```ggsql
+SELECT date, revenue, region
+FROM sales
+WHERE year = 2024
+VISUALISE date AS x, revenue AS y, region AS color
+DRAW line
+LABEL title = 'Sales by Region'
+THEME minimal
+```
+
+## Project Status
+
+✨ **Active Development** - Core functionality is working with ongoing feature additions and refinements.
+
+**Completed:**
+
+- ✅ Complete tree-sitter grammar with SQL + VISUALISE parsing
+- ✅ Full AST type system with validation
+- ✅ DuckDB reader with comprehensive type handling
+- ✅ Vega-Lite writer with multi-layer support
+- ✅ CLI tool (`ggsql`) with parse, exec, and validate commands
+- ✅ REST API server (`ggsql-rest`) with CORS support
+- ✅ Jupyter kernel (`ggsql-jupyter`) with inline Vega-Lite visualizations
+- ✅ knitr-engine (`ggsql-jupyter`) with inline Vega-Lite visualizations
+- ✅ VS Code extension (`ggsql-vscode`) with syntax highlighting for `.ggsql` files
+
+**Planned:**
+
+- 📋 Additional readers
+- 📋 Additional writers
+- 📋 More geom types and statistical transformations
+- 📋 Enhanced theme system
+
+## Architecture
+
+ggSQL splits queries at the `VISUALISE` boundary:
+
+- **SQL portion** → passed to pluggable readers (DuckDB, PostgreSQL, CSV, etc.)
+- **VISUALISE portion** → parsed and compiled into visualization specifications
+- **Output** → rendered via pluggable writers (ggplot2, PNG, Vega-Lite, etc.)
+
+## Development Setup
+
+### Getting Started
+
+1. **Clone the repository:**
+
+   ```bash
+   git clone https://github.com/georgestagg/ggsql
+   cd ggsql
+   ```
+
+2. **Install tree-sitter CLI:**
+
+   ```bash
+   npm install -g tree-sitter-cli
+   ```
+
+3. **Build the project:**
+
+   ```bash
+   cargo build
+   ```
+
+4. **Run tests:**
+   ```bash
+   cargo test
+   ```
+
+## Project Structure
+
+```
+ggsql/
+├── Cargo.toml                       # Workspace root configuration
+├── README.md                        # This file
+│
+├── tree-sitter-ggsql/               # Tree-sitter grammar package
+│
+├── src/                             # Main library
+│   ├── lib.rs                       # Public API and re-exports
+│   ├── cli.rs                       # Command-line interface
+│   ├── rest.rs                      # REST API server
+│   ├── parser/                      # Parsing subsystem
+│   ├── reader/                      # Data source readers
+│   └── writer/                      # Visualization writers
+│
+├── ggsql-jupyter/                   # Jupyter kernel
+│
+└── ggsql-vscode/                    # VS Code extension
+```
+
+## Development Workflow
+
+### Running Tests
+
+```bash
+# Run all tests
+cargo test
+
+# Run specific test modules
+cargo test ast                       # AST type tests
+cargo test splitter                  # Query splitter tests
+cargo test parser                    # All parser tests
+
+# Run without default features (avoids database dependencies)
+cargo test --no-default-features
+
+# Run with specific features
+cargo test --features duckdb,sqlite
+```
+
+### Working with the Grammar
+
+The tree-sitter grammar is in `tree-sitter-ggsql/grammar.js`. After making changes:
+
+1. **Regenerate the parser:**
+
+   ```bash
+   cd tree-sitter-ggsql
+   tree-sitter generate
+   ```
+
+2. **Test the grammar:**
+
+   ```bash
+   # Test parsing a specific file
+   tree-sitter parse test/corpus/basic.txt
+
+   # Test all corpus files
+   tree-sitter test
+   ```
+
+3. **Debug parsing issues:**
+
+   ```bash
+   # Enable debug mode
+   tree-sitter parse --debug test/corpus/basic.txt
+
+   # Check for conflicts
+   tree-sitter generate --report-states-for-rule=query
+   ```
+
+### Code Organization
+
+- **AST Types** (`src/parser/ast.rs`): Core data structures representing parsed ggSQL
+- **Query Splitter** (`src/parser/splitter.rs`): Separates SQL from VISUALISE portions
+- **AST Builder** (`src/parser/builder.rs`): Converts tree-sitter parse trees to typed AST
+- **Error Handling** (`src/parser/error.rs`): Parse-time error types and formatting
+
+### Adding New Grammar Features
+
+1. **Update the grammar** in `tree-sitter-ggsql/grammar.js`
+2. **Add corresponding AST types** in `src/parser/ast.rs`
+3. **Update the AST builder** in `src/parser/builder.rs`
+4. **Add test cases** for the new feature
+5. **Update syntax highlighting** in `tree-sitter-ggsql/queries/highlights.scm`
+
+## Testing Strategy
+
+### Unit Tests
+
+Located alongside the code they test:
+
+- `src/parser/ast.rs` - AST type functionality and validation
+- `src/parser/splitter.rs` - Query splitting edge cases
+- `src/parser/builder.rs` - CST to AST conversion
+
+### Integration Tests
+
+- Full parsing pipeline tests in `src/parser/mod.rs`
+- End-to-end query processing (planned)
+
+### Grammar Tests
+
+- `tree-sitter-ggsql/test/corpus/` - Example queries with expected parse trees
+- Run with `tree-sitter test`
+
+### Running Specific Test Categories
+
+```bash
+# Core AST functionality
+cargo test ast::tests
+
+# Query splitting logic
+cargo test splitter::tests
+
+# Tree-sitter grammar
+cd tree-sitter-ggsql && tree-sitter test
+
+# All parser integration tests
+cargo test parser
+```
+
+## Grammar Specification
+
+See [CLAUDE.md](CLAUDE.md) for the in-progress ggSQL grammar specification, including:
+
+- Syntax reference
+- AST structure
+- Implementation phases and architecture
+- Design principles and philosophy
+
+Key grammar elements:
+
+- `VISUALISE [mappings] [FROM source]` - Entry point with global aesthetic mappings
+- `DRAW <geom> [MAPPING] [SETTING] [FILTER]` - Define geometric layers (point, line, bar, etc.)
+- `SCALE <aesthetic> SETTING` - Configure data-to-visual mappings
+- `FACET` - Create small multiples (WRAP for flowing layout, BY for grid)
+- `COORD` - Coordinate transformations (cartesian, flip, polar)
+- `LABEL`, `THEME`, `GUIDE` - Styling and annotation
+
+## Jupyter Kernel
+
+The `ggsql-jupyter` package provides a Jupyter kernel for interactive ggSQL queries with inline Vega-Lite visualizations.
+
+### Installation
+
+```bash
+cargo build --release --package ggsql-jupyter
+./target/release/ggsql-jupyter --install
+```
+
+### Usage
+
+After installation, create a new notebook with the "ggSQL" kernel or use `%kernel ggsql` in an existing notebook.
+
+```sql
+-- Create data
+CREATE TABLE sales AS
+SELECT * FROM (VALUES
+    ('2024-01-01'::DATE, 100, 'North'),
+    ('2024-01-02'::DATE, 120, 'South')
+) AS t(date, revenue, region)
+
+-- Visualize with ggSQL using global mapping
+SELECT * FROM sales
+VISUALISE date AS x, revenue AS y, region AS color
+DRAW line
+SCALE x SETTING type => 'date'
+LABEL title = 'Sales Trends'
+```
+
+The kernel maintains a persistent DuckDB session across cells, so you can create tables in one cell and query them in another.
+
+### Quarto
+
+A Quarto example can be found in `ggsql-jupyter/tests/quarto/doc.qmd`.
+
+## VS Code Extension
+
+The `ggsql-vscode` extension provides syntax highlighting for ggSQL files in Visual Studio Code.
+
+### Installation
+
+```bash
+# Package the extension
+cd ggsql-vscode
+npm install -g @vscode/vsce
+vsce package
+
+# Install the VSIX file
+code --install-extension ggsql-0.1.0.vsix
+```
+
+### Features
+
+- **Syntax highlighting** for ggSQL keywords, geoms, aesthetics, and SQL
+- **File association** for `.ggsql`, `.ggsql.sql`, and `.gsql` extensions
+- **Bracket matching** and auto-closing for parentheses and brackets
+- **Comment support** for `--` single-line and `/* */` multi-line comments
+
+The extension uses a TextMate grammar that highlights:
+
+- SQL keywords (SELECT, FROM, WHERE, JOIN, etc.)
+- ggSQL clauses (VISUALISE, DRAW, SCALE, COORD, FACET, etc.)
+- Geometric objects (point, line, bar, area, etc.)
+- Aesthetics (x, y, color, size, shape, etc.)
+- Scale types (linear, log10, date, viridis, etc.)
+
+## CLI
+
+### Installation
+
+```bash
+cargo install --path src
+```

--- a/doc/styles.css
+++ b/doc/styles.css
@@ -1,0 +1,1 @@
+/* css styles */


### PR DESCRIPTION
This PR adds a quarto website scaffold that we can begin to populate. Currently the main landing page is just a copy of the readme, and I have also copied the doc.qmd into an examples.qmd

We should set up CI which would give us some level of end-to-end testing through the examples.qmd file