### PR TITLE
Update publish.yaml

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -10,6 +10,8 @@ on:
 jobs:
   publish-website:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Check out repository
         uses: actions/checkout@v4


### PR DESCRIPTION
This is an amendement to #40.

I forgot to give the workflow permission to write to the gh-pages branch.
In addition to this PR, there are a few steps I can't take, described in https://quarto.org/docs/publishing/github-pages.html#publish-action.

In particular:

>  The action will render your content and publish it to GitHub Pages, thus you need to ensure that GitHub Actions has permission to write to your repository. This is done by checking the Read and write permissions box under Workflow permissions in the Actions section of your repository Settings.

> Consult the Pages section of your repository Settings to see what the URL and publish status for your site is.

@georgestagg could you take a look at these settings?