### PR TITLE
refactor constants out and assign session id

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,8 @@ proptest = "1.4"
 # Utilities
 regex = "1.10"
 chrono = "0.4"
+const_format = "0.2"
+uuid = { version = "1.0", features = ["v4"] }
 
 # Web server
 axum = "0.7"

--- a/src/Cargo.toml
+++ b/src/Cargo.toml
@@ -51,6 +51,8 @@ thiserror.workspace = true
 # Utilities
 regex.workspace = true
 chrono.workspace = true
+const_format.workspace = true
+uuid.workspace = true
 
 # Web server (optional)
 axum = { workspace = true, optional = true }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,6 +33,7 @@ ggsql splits queries at the `VISUALISE` boundary:
 - [`writers`] - Output format abstraction layer
 */
 
+pub mod naming;
 pub mod parser;
 pub mod plot;
 
@@ -93,7 +94,7 @@ mod integration_tests {
     /// Helper to wrap a DataFrame in a data map for testing
     fn wrap_data(df: DataFrame) -> HashMap<String, DataFrame> {
         let mut data_map = HashMap::new();
-        data_map.insert("__global__".to_string(), df);
+        data_map.insert(naming::GLOBAL_DATA_KEY.to_string(), df);
         data_map
     }
 
@@ -147,7 +148,9 @@ mod integration_tests {
 
         // Data values should be ISO temporal strings
         // (DuckDB returns Datetime for DATE + INTERVAL, so we get ISO datetime format)
-        let data_values = vl_spec["datasets"]["__global__"].as_array().unwrap();
+        let data_values = vl_spec["datasets"][naming::GLOBAL_DATA_KEY]
+            .as_array()
+            .unwrap();
         let date_str = data_values[0]["date"].as_str().unwrap();
         assert!(
             date_str.starts_with("2024-01-01"),
@@ -201,7 +204,9 @@ mod integration_tests {
         assert_eq!(vl_spec["layer"][0]["encoding"]["x"]["type"], "temporal");
 
         // Data values should be ISO datetime strings
-        let data_values = vl_spec["datasets"]["__global__"].as_array().unwrap();
+        let data_values = vl_spec["datasets"][naming::GLOBAL_DATA_KEY]
+            .as_array()
+            .unwrap();
         assert!(data_values[0]["timestamp"]
             .as_str()
             .unwrap()
@@ -256,7 +261,9 @@ mod integration_tests {
         assert_eq!(vl_spec["layer"][0]["encoding"]["y"]["type"], "quantitative");
 
         // Data values should be numbers (not strings!)
-        let data_values = vl_spec["datasets"]["__global__"].as_array().unwrap();
+        let data_values = vl_spec["datasets"][naming::GLOBAL_DATA_KEY]
+            .as_array()
+            .unwrap();
         assert_eq!(data_values[0]["int_col"], 1);
         assert_eq!(data_values[0]["float_col"], 2.5);
         assert_eq!(data_values[0]["bool_col"], true);
@@ -303,7 +310,9 @@ mod integration_tests {
         let vl_spec: serde_json::Value = serde_json::from_str(&json_str).unwrap();
 
         // Check null handling in JSON
-        let data_values = vl_spec["datasets"]["__global__"].as_array().unwrap();
+        let data_values = vl_spec["datasets"][naming::GLOBAL_DATA_KEY]
+            .as_array()
+            .unwrap();
         assert_eq!(data_values[0]["int_col"], 1);
         assert_eq!(data_values[0]["float_col"], 2.5);
         assert_eq!(data_values[1]["float_col"], serde_json::Value::Null);
@@ -434,7 +443,9 @@ mod integration_tests {
         let vl_spec: serde_json::Value = serde_json::from_str(&json_str).unwrap();
 
         // Check values are preserved
-        let data_values = vl_spec["datasets"]["__global__"].as_array().unwrap();
+        let data_values = vl_spec["datasets"][naming::GLOBAL_DATA_KEY]
+            .as_array()
+            .unwrap();
         let small_val = data_values[0]["small"].as_f64().unwrap();
         let medium_val = data_values[0]["medium"].as_f64().unwrap();
         let large_val = data_values[0]["large"].as_f64().unwrap();
@@ -492,7 +503,9 @@ mod integration_tests {
         assert_eq!(vl_spec["layer"][0]["encoding"]["y"]["type"], "quantitative");
 
         // Check values
-        let data_values = vl_spec["datasets"]["__global__"].as_array().unwrap();
+        let data_values = vl_spec["datasets"][naming::GLOBAL_DATA_KEY]
+            .as_array()
+            .unwrap();
         assert_eq!(data_values[0]["tiny"], 1);
         assert_eq!(data_values[0]["small"], 1000);
         assert_eq!(data_values[0]["int"], 1000000);
@@ -522,22 +535,22 @@ mod integration_tests {
         // Verify constants were injected into global data (not layer-specific data)
         // Both layers share __global__ data for faceting compatibility
         assert!(
-            prepared.data.contains_key("__global__"),
+            prepared.data.contains_key(naming::GLOBAL_DATA_KEY),
             "Should have global data with constants injected"
         );
         // Layers without filters should NOT have their own data entries
         assert!(
-            !prepared.data.contains_key("__layer_0__"),
+            !prepared.data.contains_key(&naming::layer_key(0)),
             "Layer 0 should use global data, not layer-specific data"
         );
         assert!(
-            !prepared.data.contains_key("__layer_1__"),
+            !prepared.data.contains_key(&naming::layer_key(1)),
             "Layer 1 should use global data, not layer-specific data"
         );
         assert_eq!(prepared.specs.len(), 1);
 
         // Verify global data contains layer-indexed constant columns
-        let global_df = prepared.data.get("__global__").unwrap();
+        let global_df = prepared.data.get(naming::GLOBAL_DATA_KEY).unwrap();
         let col_names = global_df.get_column_names();
         assert!(
             col_names.iter().any(|c| *c == "__ggsql_const_color_0__"),
@@ -575,7 +588,7 @@ mod integration_tests {
         );
 
         // All layers should use the same global data
-        let global_data = &vl_spec["datasets"]["__global__"];
+        let global_data = &vl_spec["datasets"][naming::GLOBAL_DATA_KEY];
         assert!(global_data.is_array(), "Should have global data array");
 
         // Verify constant values appear in the global data with layer-indexed names
@@ -629,29 +642,29 @@ mod integration_tests {
 
         // All layers should use global data for faceting to work
         assert!(
-            prepared.data.contains_key("__global__"),
+            prepared.data.contains_key(naming::GLOBAL_DATA_KEY),
             "Should have global data"
         );
         // No layer-specific data should be created
         assert!(
-            !prepared.data.contains_key("__layer_0__"),
+            !prepared.data.contains_key(&naming::layer_key(0)),
             "Layer 0 should use global data"
         );
         assert!(
-            !prepared.data.contains_key("__layer_1__"),
+            !prepared.data.contains_key(&naming::layer_key(1)),
             "Layer 1 should use global data"
         );
         assert!(
-            !prepared.data.contains_key("__layer_2__"),
+            !prepared.data.contains_key(&naming::layer_key(2)),
             "Layer 2 should use global data"
         );
         assert!(
-            !prepared.data.contains_key("__layer_3__"),
+            !prepared.data.contains_key(&naming::layer_key(3)),
             "Layer 3 should use global data"
         );
 
         // Verify global data has all layer-indexed constant columns
-        let global_df = prepared.data.get("__global__").unwrap();
+        let global_df = prepared.data.get(naming::GLOBAL_DATA_KEY).unwrap();
         let col_names = global_df.get_column_names();
         assert!(
             col_names.iter().any(|c| *c == "__ggsql_const_color_0__"),
@@ -717,12 +730,12 @@ mod integration_tests {
 
         // Should have global data with the constant injected
         assert!(
-            prepared.data.contains_key("__global__"),
+            prepared.data.contains_key(naming::GLOBAL_DATA_KEY),
             "Should have global data"
         );
 
         // Verify global data has the constant columns for both layers
-        let global_df = prepared.data.get("__global__").unwrap();
+        let global_df = prepared.data.get(naming::GLOBAL_DATA_KEY).unwrap();
         let col_names = global_df.get_column_names();
         assert!(
             col_names.iter().any(|c| *c == "__ggsql_const_color_0__"),
@@ -756,7 +769,9 @@ mod integration_tests {
         );
 
         // Both constants should have the same value "value"
-        let data = &vl_spec["datasets"]["__global__"].as_array().unwrap()[0];
+        let data = &vl_spec["datasets"][naming::GLOBAL_DATA_KEY]
+            .as_array()
+            .unwrap()[0];
         assert_eq!(data["__ggsql_const_color_0__"], "value");
         assert_eq!(data["__ggsql_const_color_1__"], "value");
     }

--- a/src/naming.rs
+++ b/src/naming.rs
@@ -1,0 +1,356 @@
+//! Centralized naming conventions for ggsql-generated identifiers.
+//!
+//! All synthetic column names, table names, and keys use double-underscore
+//! prefix/suffix pattern to avoid collision with user-defined names.
+//!
+//! # Categories
+//!
+//! - **CTE tables**: Temp tables created from WITH clause CTEs (`__ggsql_cte_<name>_<uuid>__`)
+//! - **Constant columns**: Synthetic columns for literal values (`__ggsql_const_<aesthetic>__`)
+//! - **Stat columns**: Columns produced by statistical transforms (`__ggsql_stat__<name>`)
+//! - **Data keys**: Keys for data sources in the data map (`__ggsql_global__`, `__ggsql_layer_<idx>__`)
+//! - **Ordering column**: Window function for preserving data order (`__ggsql_order__`)
+//! - **Session ID**: Process-wide UUID for temp table uniqueness
+
+use const_format::concatcp;
+use std::sync::LazyLock;
+use uuid::Uuid;
+
+// ============================================================================
+// Base Building Blocks
+// ============================================================================
+
+/// Base prefix for all ggsql SQL-level identifiers
+const GGSQL_PREFIX: &str = "__ggsql_";
+
+/// Suffix for all ggsql identifiers (double underscore)
+const GGSQL_SUFFIX: &str = "__";
+
+// ============================================================================
+// Session ID (Process-wide UUID for temp table uniqueness)
+// ============================================================================
+
+/// Process-wide session ID, generated once on first access.
+/// Ensures temp table names are unique per process, avoiding collisions
+/// when multiple processes use the same database connection.
+static SESSION_ID: LazyLock<String> = LazyLock::new(|| Uuid::new_v4().simple().to_string());
+
+/// Get the current session ID (32 hex characters, no dashes).
+///
+/// This ID is generated once per process and remains constant for the
+/// lifetime of the process. Different processes will have different IDs.
+///
+/// # Example
+/// ```
+/// use ggsql::naming;
+/// let id = naming::session_id();
+/// assert_eq!(id.len(), 32); // UUID v4 simple format
+/// ```
+pub fn session_id() -> &'static str {
+    &SESSION_ID
+}
+
+// ============================================================================
+// Derived Constants
+// ============================================================================
+
+/// Full prefix for constant columns: `__ggsql_const_`
+const CONST_PREFIX: &str = concatcp!(GGSQL_PREFIX, "const_");
+
+/// Full prefix for stat columns: `__ggsql_stat__`
+const STAT_PREFIX: &str = concatcp!(GGSQL_PREFIX, "stat_");
+
+/// Full prefix for CTE tables: `__ggsql_cte_`
+const CTE_PREFIX: &str = concatcp!(GGSQL_PREFIX, "cte_");
+
+/// Full prefix for CTE tables: `__ggsql_cte_`
+const LAYER_PREFIX: &str = concatcp!(GGSQL_PREFIX, "layer_");
+
+/// Key for global data in the layer data HashMap.
+/// Used as the key in PreparedData.data to store global data that applies to all layers.
+/// This is NOT a SQL table name - use `global_table()` for SQL statements.
+pub const GLOBAL_DATA_KEY: &str = concatcp!(GGSQL_PREFIX, "global", GGSQL_SUFFIX);
+
+/// Column name for row ordering in Vega-Lite (used by Path geom)
+pub const ORDER_COLUMN: &str = concatcp!(GGSQL_PREFIX, "order", GGSQL_SUFFIX);
+
+/// Alias for schema extraction queries
+pub const SCHEMA_ALIAS: &str = concatcp!(GGSQL_SUFFIX, "schema", GGSQL_SUFFIX);
+
+// ============================================================================
+// Constructor Functions
+// ============================================================================
+
+/// Generate SQL temp table name for global data.
+///
+/// Includes the session UUID to avoid collisions when multiple processes
+/// use the same database connection. Format: `__ggsql_global_<uuid>__`
+///
+/// # Example
+/// ```
+/// use ggsql::naming;
+/// let table = naming::global_table();
+/// assert!(table.starts_with("__ggsql_global_"));
+/// assert!(table.ends_with("__"));
+/// // Contains 32-character UUID
+/// assert_eq!(table.len(), "__ggsql_global_".len() + 32 + "__".len());
+/// ```
+pub fn global_table() -> String {
+    format!("{}global_{}{}", GGSQL_PREFIX, session_id(), GGSQL_SUFFIX)
+}
+
+/// Generate temp table name for a materialized CTE.
+///
+/// Includes the session UUID to avoid collisions when multiple processes
+/// use the same database connection. Format: `__ggsql_cte_<name>_<uuid>__`
+///
+/// # Example
+/// ```
+/// use ggsql::naming;
+/// let table = naming::cte_table("sales");
+/// assert!(table.starts_with("__ggsql_cte_sales_"));
+/// assert!(table.ends_with("__"));
+/// ```
+pub fn cte_table(cte_name: &str) -> String {
+    format!(
+        "{}{}_{}{}",
+        CTE_PREFIX,
+        cte_name,
+        session_id(),
+        GGSQL_SUFFIX
+    )
+}
+
+/// Generate column name for a constant aesthetic value.
+///
+/// Used when a single layer has a literal aesthetic value that needs
+/// to be converted to a column for Vega-Lite encoding.
+///
+/// # Example
+/// ```
+/// use ggsql::naming;
+/// assert_eq!(naming::const_column("color"), "__ggsql_const_color__");
+/// ```
+pub fn const_column(aesthetic: &str) -> String {
+    format!("{}{}{}", CONST_PREFIX, aesthetic, GGSQL_SUFFIX)
+}
+
+/// Generate indexed column name for constant aesthetic (multi-layer).
+///
+/// Used when injecting constants into global data so different layers
+/// can have different values for the same aesthetic.
+///
+/// # Example
+/// ```
+/// use ggsql::naming;
+/// assert_eq!(naming::const_column_indexed("color", 0), "__ggsql_const_color_0__");
+/// assert_eq!(naming::const_column_indexed("color", 1), "__ggsql_const_color_1__");
+/// ```
+pub fn const_column_indexed(aesthetic: &str, layer_idx: usize) -> String {
+    format!(
+        "{}{}_{}{}",
+        CONST_PREFIX, aesthetic, layer_idx, GGSQL_SUFFIX
+    )
+}
+
+/// Generate column name for statistical transform output.
+///
+/// These columns are produced by stat transforms like histogram and bar.
+///
+/// # Example
+/// ```
+/// use ggsql::naming;
+/// assert_eq!(naming::stat_column("count"), "__ggsql_stat_count");
+/// assert_eq!(naming::stat_column("bin"), "__ggsql_stat_bin");
+/// ```
+pub fn stat_column(stat_name: &str) -> String {
+    format!("{}{}", STAT_PREFIX, stat_name)
+}
+
+/// Generate dataset key for layer-specific data.
+///
+/// Used when a layer has its own data source (FROM clause, filter, etc.)
+/// that differs from the global data.
+///
+/// # Example
+/// ```
+/// use ggsql::naming;
+/// assert_eq!(naming::layer_key(0), "__ggsql_layer_0__");
+/// assert_eq!(naming::layer_key(2), "__ggsql_layer_2__");
+/// ```
+pub fn layer_key(layer_idx: usize) -> String {
+    format!("{}{}{}", LAYER_PREFIX, layer_idx, GGSQL_SUFFIX)
+}
+
+// ============================================================================
+// Detection Functions
+// ============================================================================
+
+/// Check if a column name is a synthetic constant column.
+///
+/// # Example
+/// ```
+/// use ggsql::naming;
+/// assert!(naming::is_const_column("__ggsql_const_color__"));
+/// assert!(naming::is_const_column("__ggsql_const_color_0__"));
+/// assert!(!naming::is_const_column("color"));
+/// ```
+pub fn is_const_column(name: &str) -> bool {
+    name.starts_with(CONST_PREFIX)
+}
+
+/// Check if a column name is a statistical transform column.
+///
+/// # Example
+/// ```
+/// use ggsql::naming;
+/// assert!(naming::is_stat_column("__ggsql_stat_count"));
+/// assert!(naming::is_stat_column("__ggsql_stat_bin"));
+/// assert!(!naming::is_stat_column("count"));
+/// ```
+pub fn is_stat_column(name: &str) -> bool {
+    name.starts_with(STAT_PREFIX)
+}
+
+/// Check if a column name is any synthetic ggsql column.
+///
+/// # Example
+/// ```
+/// use ggsql::naming;
+/// assert!(naming::is_synthetic_column("__ggsql_const_color__"));
+/// assert!(naming::is_synthetic_column("__ggsql_stat_count"));
+/// assert!(!naming::is_synthetic_column("revenue"));
+/// ```
+pub fn is_synthetic_column(name: &str) -> bool {
+    is_const_column(name) || is_stat_column(name)
+}
+
+/// Extract the stat name from a stat column (for display purposes).
+///
+/// Returns the human-readable name from a stat column name.
+///
+/// # Example
+/// ```
+/// use ggsql::naming;
+/// assert_eq!(naming::extract_stat_name("__ggsql_stat_count"), Some("count"));
+/// assert_eq!(naming::extract_stat_name("__ggsql_stat_bin"), Some("bin"));
+/// assert_eq!(naming::extract_stat_name("regular_column"), None);
+/// ```
+pub fn extract_stat_name(name: &str) -> Option<&str> {
+    name.strip_prefix(STAT_PREFIX)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_session_id() {
+        let id = session_id();
+        // UUID v4 simple format is 32 hex characters
+        assert_eq!(id.len(), 32);
+        // Should be consistent across calls
+        assert_eq!(session_id(), id);
+    }
+
+    #[test]
+    fn test_global_table() {
+        let table = global_table();
+        assert!(table.starts_with("__ggsql_global_"));
+        assert!(table.ends_with("__"));
+        // Should be consistent across calls (same session)
+        assert_eq!(global_table(), table);
+        // Should contain session ID
+        assert!(table.contains(session_id()));
+    }
+
+    #[test]
+    fn test_cte_table() {
+        let table = cte_table("sales");
+        assert!(table.starts_with("__ggsql_cte_sales_"));
+        assert!(table.ends_with("__"));
+        // Should contain session ID
+        assert!(table.contains(session_id()));
+
+        let table2 = cte_table("monthly_totals");
+        assert!(table2.starts_with("__ggsql_cte_monthly_totals_"));
+        assert!(table2.ends_with("__"));
+    }
+
+    #[test]
+    fn test_const_column() {
+        assert_eq!(const_column("color"), "__ggsql_const_color__");
+        assert_eq!(const_column("fill"), "__ggsql_const_fill__");
+    }
+
+    #[test]
+    fn test_const_column_indexed() {
+        assert_eq!(const_column_indexed("color", 0), "__ggsql_const_color_0__");
+        assert_eq!(const_column_indexed("color", 1), "__ggsql_const_color_1__");
+        assert_eq!(const_column_indexed("size", 5), "__ggsql_const_size_5__");
+    }
+
+    #[test]
+    fn test_stat_column() {
+        assert_eq!(stat_column("count"), "__ggsql_stat_count");
+        assert_eq!(stat_column("bin"), "__ggsql_stat_bin");
+        assert_eq!(stat_column("density"), "__ggsql_stat_density");
+    }
+
+    #[test]
+    fn test_layer_key() {
+        assert_eq!(layer_key(0), "__ggsql_layer_0__");
+        assert_eq!(layer_key(1), "__ggsql_layer_1__");
+        assert_eq!(layer_key(10), "__ggsql_layer_10__");
+    }
+
+    #[test]
+    fn test_is_const_column() {
+        assert!(is_const_column("__ggsql_const_color__"));
+        assert!(is_const_column("__ggsql_const_color_0__"));
+        assert!(is_const_column("__ggsql_const_fill__"));
+        assert!(!is_const_column("color"));
+        assert!(!is_const_column("__ggsql_stat_count"));
+    }
+
+    #[test]
+    fn test_is_stat_column() {
+        assert!(is_stat_column("__ggsql_stat_count"));
+        assert!(is_stat_column("__ggsql_stat_bin"));
+        assert!(!is_stat_column("count"));
+        assert!(!is_stat_column("__ggsql_const_color__"));
+    }
+
+    #[test]
+    fn test_is_synthetic_column() {
+        assert!(is_synthetic_column("__ggsql_const_color__"));
+        assert!(is_synthetic_column("__ggsql_stat_count"));
+        assert!(!is_synthetic_column("revenue"));
+        assert!(!is_synthetic_column("date"));
+    }
+
+    #[test]
+    fn test_extract_stat_name() {
+        assert_eq!(extract_stat_name("__ggsql_stat_count"), Some("count"));
+        assert_eq!(extract_stat_name("__ggsql_stat_bin"), Some("bin"));
+        assert_eq!(extract_stat_name("__ggsql_stat_density"), Some("density"));
+        assert_eq!(extract_stat_name("regular_column"), None);
+        assert_eq!(extract_stat_name("__ggsql_const_color__"), None);
+    }
+
+    #[test]
+    fn test_constants() {
+        assert_eq!(GLOBAL_DATA_KEY, "__ggsql_global__");
+        assert_eq!(ORDER_COLUMN, "__ggsql_order__");
+        assert_eq!(SCHEMA_ALIAS, "__schema__");
+    }
+
+    #[test]
+    fn test_prefixes_built_from_components() {
+        // Verify prefixes are correctly composed from building blocks
+        assert_eq!(CONST_PREFIX, "__ggsql_const_");
+        assert_eq!(STAT_PREFIX, "__ggsql_stat_");
+        assert_eq!(CTE_PREFIX, "__ggsql_cte_");
+        assert_eq!(LAYER_PREFIX, "__ggsql_layer_");
+    }
+}

--- a/src/plot/layer/geom/histogram.rs
+++ b/src/plot/layer/geom/histogram.rs
@@ -4,6 +4,7 @@ use std::collections::HashMap;
 
 use super::types::get_column_name;
 use super::{DefaultParam, DefaultParamValue, GeomAesthetics, GeomTrait, GeomType, StatResult};
+use crate::naming;
 use crate::plot::types::ParameterValue;
 use crate::{DataFrame, GgsqlError, Mappings, Result};
 
@@ -186,25 +187,36 @@ fn stat_histogram(
     // Use semantically meaningful column names with prefix to avoid conflicts
     // Include bin (start), bin_end (end), count/sum, and density
     // Use a two-stage query: first GROUP BY, then calculate density with window function
+    let stat_bin = naming::stat_column("bin");
+    let stat_bin_end = naming::stat_column("bin_end");
+    let stat_count = naming::stat_column("count");
+    let stat_density = naming::stat_column("density");
+
     let (binned_select, final_select) = if group_by.is_empty() {
         (
             format!(
-                "{} AS __ggsql_stat__bin, {} AS __ggsql_stat__bin_end, {} AS __ggsql_stat__count",
-                bin_expr, bin_end_expr, agg_expr
+                "{} AS {}, {} AS {}, {} AS {}",
+                bin_expr, stat_bin, bin_end_expr, stat_bin_end, agg_expr, stat_count
             ),
-            "*, __ggsql_stat__count * 1.0 / SUM(__ggsql_stat__count) OVER () AS __ggsql_stat__density".to_string()
+            format!(
+                "*, {count} * 1.0 / SUM({count}) OVER () AS {density}",
+                count = stat_count,
+                density = stat_density
+            ),
         )
     } else {
         let grp_cols = group_by.join(", ");
         (
             format!(
-                "{}, {} AS __ggsql_stat__bin, {} AS __ggsql_stat__bin_end, {} AS __ggsql_stat__count",
-                grp_cols, bin_expr, bin_end_expr, agg_expr
+                "{}, {} AS {}, {} AS {}, {} AS {}",
+                grp_cols, bin_expr, stat_bin, bin_end_expr, stat_bin_end, agg_expr, stat_count
             ),
             format!(
-                "*, __ggsql_stat__count * 1.0 / SUM(__ggsql_stat__count) OVER (PARTITION BY {}) AS __ggsql_stat__density",
-                grp_cols
-            )
+                "*, {count} * 1.0 / SUM({count}) OVER (PARTITION BY {grp}) AS {density}",
+                count = stat_count,
+                grp = grp_cols,
+                density = stat_density
+            ),
         )
     };
 

--- a/src/plot/main.rs
+++ b/src/plot/main.rs
@@ -19,6 +19,7 @@
 //! └─ theme: Option<Theme>           (optional, from THEME clause)
 //! ```
 
+use crate::naming;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
@@ -164,7 +165,7 @@ impl Plot {
             for (aesthetic, value) in &layer.mappings.aesthetics {
                 if let AestheticValue::Column { name, .. } = value {
                     // Skip synthetic constant columns
-                    if name.starts_with("__ggsql_const_") {
+                    if naming::is_const_column(name) {
                         continue;
                     }
 
@@ -177,7 +178,7 @@ impl Plot {
                     }
 
                     // Compute the label from the column name
-                    let column_name = if let Some(stat_name) = name.strip_prefix("__ggsql_stat__") {
+                    let column_name = if let Some(stat_name) = naming::extract_stat_name(name) {
                         stat_name.to_string()
                     } else {
                         name.clone()

--- a/src/reader/data.rs
+++ b/src/reader/data.rs
@@ -140,12 +140,14 @@ fn tokens_from_tree(
 #[cfg(feature = "duckdb")]
 #[test]
 fn test_builtin_data_is_available() {
+    use crate::naming;
+
     let reader = crate::reader::DuckDBReader::from_connection_string("duckdb://memory").unwrap();
 
     // We need the VISUALISE here so `prepare_data` doesn't get tripped up
     let query = "SELECT * FROM ggsql:penguins VISUALISE";
     let result = crate::execute::prepare_data(query, &reader).unwrap();
-    let dataframe = result.data.get("__global__").unwrap();
+    let dataframe = result.data.get(naming::GLOBAL_DATA_KEY).unwrap();
     let colnames = dataframe.get_column_names();
 
     assert_eq!(
@@ -164,7 +166,7 @@ fn test_builtin_data_is_available() {
 
     let query = "VISUALISE * FROM ggsql:airquality";
     let result = crate::execute::prepare_data(query, &reader).unwrap();
-    let dataframe = result.data.get("__global__").unwrap();
+    let dataframe = result.data.get(naming::GLOBAL_DATA_KEY).unwrap();
     let colnames = dataframe.get_column_names();
 
     assert_eq!(


### PR DESCRIPTION
Fix #68 

This PR started as a refactor exercise so that all our "magic strings" are collected in one place. But since this also provided a good opportunity to assign a session id to tables I added that as well