### PR TITLE
chore: upgrade to Vega-Lite v6 and Vega-Embed v7

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -512,7 +512,7 @@ impl Writer for VegaLiteWriter {
 
         // 2. Build Vega-Lite spec
         let mut vl_spec = json!({
-            "$schema": "https://vega.github.io/schema/vega-lite/v5.json",
+            "$schema": "https://vega.github.io/schema/vega-lite/v6.json",
             "data": {"values": data_values},
             "width": 600,
             "autosize": {"type": "fit", "contains": "padding"}
@@ -1256,7 +1256,7 @@ Plot {
 
 ```json
 {
-  "$schema": "https://vega.github.io/schema/vega-lite/v5.json",
+  "$schema": "https://vega.github.io/schema/vega-lite/v6.json",
   "data": {
     "values": [
       {"sale_date": "2024-01-01", "region": "North", "total": 150},

--- a/ggsql-jupyter/src/display.rs
+++ b/ggsql-jupyter/src/display.rs
@@ -69,8 +69,8 @@ fn format_vegalite(spec: String) -> Value {
         paths: {{
           'dom-ready': 'https://cdn.jsdelivr.net/npm/domready@1/ready.min',
           'vega': 'https://cdn.jsdelivr.net/npm/vega@5/build/vega.min',
-          'vega-lite': 'https://cdn.jsdelivr.net/npm/vega-lite@5/build/vega-lite.min',
-          'vega-embed': 'https://cdn.jsdelivr.net/npm/vega-embed@6/build/vega-embed.min'
+          'vega-lite': 'https://cdn.jsdelivr.net/npm/vega-lite@6/build/vega-lite.min',
+          'vega-embed': 'https://cdn.jsdelivr.net/npm/vega-embed@7/build/vega-embed.min'
         }}
       }});
 
@@ -101,8 +101,8 @@ fn format_vegalite(spec: String) -> Value {
 
       Promise.all([
         loadScript('https://cdn.jsdelivr.net/npm/vega@5'),
-        loadScript('https://cdn.jsdelivr.net/npm/vega-lite@5'),
-        loadScript('https://cdn.jsdelivr.net/npm/vega-embed@6')
+        loadScript('https://cdn.jsdelivr.net/npm/vega-lite@6'),
+        loadScript('https://cdn.jsdelivr.net/npm/vega-embed@7')
       ])
         .then(() => {{
           vegaEmbed('#' + visId, spec, options)

--- a/ggsql-jupyter/tests/test_compliance.py
+++ b/ggsql-jupyter/tests/test_compliance.py
@@ -111,10 +111,10 @@ class ggsqlKernelTests(jkt.KernelTests):
 
         # Check MIME types
         data = execute_result["content"]["data"]
-        self.assertIn("application/vnd.vegalite.v5+json", data)
+        self.assertIn("application/vnd.vegalite.v6+json", data)
 
         # Verify Vega-Lite spec structure
-        vega_spec = data["application/vnd.vegalite.v5+json"]
+        vega_spec = data["application/vnd.vegalite.v6+json"]
         self.assertIn("$schema", vega_spec)
         self.assertIn("data", vega_spec)
 

--- a/ggsql-jupyter/tests/test_integration.py
+++ b/ggsql-jupyter/tests/test_integration.py
@@ -185,10 +185,10 @@ class TestExecution:
 
         # Should have Vega-Lite MIME type
         data = content["data"]
-        assert "application/vnd.vegalite.v5+json" in data
+        assert "application/vnd.vegalite.v6+json" in data
 
         # Check Vega-Lite spec structure
-        vega_spec = data["application/vnd.vegalite.v5+json"]
+        vega_spec = data["application/vnd.vegalite.v6+json"]
         assert "$schema" in vega_spec
         assert "data" in vega_spec
         assert "mark" in vega_spec or "layer" in vega_spec

--- a/src/writer/vegalite.rs
+++ b/src/writer/vegalite.rs
@@ -31,7 +31,7 @@ use std::collections::HashMap;
 
 /// Vega-Lite JSON writer
 ///
-/// Generates Vega-Lite v5 specifications from ggsql specs and data.
+/// Generates Vega-Lite v6 specifications from ggsql specs and data.
 pub struct VegaLiteWriter {
     /// Vega-Lite schema version
     schema: String,
@@ -41,7 +41,7 @@ impl VegaLiteWriter {
     /// Create a new Vega-Lite writer with default settings
     pub fn new() -> Self {
         Self {
-            schema: "https://vega.github.io/schema/vega-lite/v5.json".to_string(),
+            schema: "https://vega.github.io/schema/vega-lite/v6.json".to_string(),
         }
     }
 


### PR DESCRIPTION
This upgrade will be useful for #74, where the current version of [`altair`](https://pypi.org/project/altair/) is expecting v6

- Upgrade Vega-Lite from v5 to v6
- Upgrade Vega-Embed from v6 to v7
- Vega remains at v5 (no change required per Vega-Lite v6 release notes)

## Changes

- `src/writer/vegalite.rs`: Update schema URL and doc comment
- `ggsql-jupyter/src/display.rs`: Update CDN URLs for vega-lite and vega-embed
- `ggsql-jupyter/tests/test_compliance.py`: Update expected MIME type
- `ggsql-jupyter/tests/test_integration.py`: Update expected MIME type
- `CLAUDE.md`: Update documentation references

## Test plan

- [x] All Rust tests pass (`cargo test -p ggsql -p ggsql-jupyter`)
- [x] Generated JSON has correct v6 schema URL
- [x] Manual verification in Vega-Lite editor confirms specs render correctly

🤖 Generated with [Claude Code](https://claude.ai/code)