### PR TITLE
Update ggsql syntax definitions

### DIFF
--- a/doc/_quarto.yml
+++ b/doc/_quarto.yml
@@ -84,6 +84,8 @@ website:
 
 format:
   html:
+    syntax-definitions:
+      - ggsql.xml
     theme:
       - cosmo
       - brand

--- a/doc/ggsql.xml
+++ b/doc/ggsql.xml
@@ -1,0 +1,854 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE language>
+<language name="ggsql"
+          version="1"
+          kateversion="5.0"
+          section="Database"
+          extensions="*.gsql;*.ggsql"
+          mimetype="text/x-ggsql"
+          casesensitive="0"
+          author="George Stagg"
+          license="MIT">
+  <highlighting>
+    <!-- SQL Keywords -->
+    <list name="sql_keywords">
+      <item>SELECT</item>
+      <item>FROM</item>
+      <item>WHERE</item>
+      <item>GROUP</item>
+      <item>ORDER</item>
+      <item>BY</item>
+      <item>HAVING</item>
+      <item>LIMIT</item>
+      <item>OFFSET</item>
+      <item>DISTINCT</item>
+      <item>ALL</item>
+      <item>JOIN</item>
+      <item>LEFT</item>
+      <item>RIGHT</item>
+      <item>INNER</item>
+      <item>OUTER</item>
+      <item>CROSS</item>
+      <item>FULL</item>
+      <item>NATURAL</item>
+      <item>LATERAL</item>
+      <item>ON</item>
+      <item>WITH</item>
+      <item>RECURSIVE</item>
+      <item>AS</item>
+      <item>INSERT</item>
+      <item>UPDATE</item>
+      <item>DELETE</item>
+      <item>CREATE</item>
+      <item>DROP</item>
+      <item>ALTER</item>
+      <item>TRUNCATE</item>
+      <item>INTO</item>
+      <item>VALUES</item>
+      <item>SET</item>
+      <item>TABLE</item>
+      <item>VIEW</item>
+      <item>INDEX</item>
+      <item>DATABASE</item>
+      <item>SCHEMA</item>
+      <item>TEMP</item>
+      <item>TEMPORARY</item>
+      <item>CASE</item>
+      <item>WHEN</item>
+      <item>THEN</item>
+      <item>ELSE</item>
+      <item>END</item>
+      <item>OVER</item>
+      <item>PARTITION</item>
+      <item>ROWS</item>
+      <item>RANGE</item>
+      <item>UNBOUNDED</item>
+      <item>PRECEDING</item>
+      <item>FOLLOWING</item>
+      <item>CURRENT</item>
+      <item>ROW</item>
+      <item>NULLS</item>
+      <item>FIRST</item>
+      <item>LAST</item>
+      <item>UNION</item>
+      <item>INTERSECT</item>
+      <item>EXCEPT</item>
+      <item>AND</item>
+      <item>OR</item>
+      <item>NOT</item>
+      <item>IN</item>
+      <item>BETWEEN</item>
+      <item>LIKE</item>
+      <item>ILIKE</item>
+      <item>EXISTS</item>
+      <item>IS</item>
+      <item>ANY</item>
+      <item>ASC</item>
+      <item>DESC</item>
+    </list>
+
+    <!-- ggsql Main Clause Keywords (triggers context switch) -->
+    <list name="clause_keywords">
+      <item>DRAW</item>
+      <item>SCALE</item>
+      <item>COORD</item>
+      <item>FACET</item>
+      <item>LABEL</item>
+      <item>GUIDE</item>
+      <item>THEME</item>
+      <item>VISUALISE</item>
+      <item>VISUALIZE</item>
+    </list>
+
+    <!-- ggsql Sub-keywords -->
+    <list name="viz_subkeywords">
+      <item>MAPPING</item>
+      <item>REMAPPING</item>
+      <item>SETTING</item>
+      <item>FILTER</item>
+      <item>WRAP</item>
+      <item>ORDER</item>
+      <item>PARTITION</item>
+    </list>
+
+    <!-- Geom Types (only in DRAW context) -->
+    <list name="geoms">
+      <item>point</item>
+      <item>line</item>
+      <item>path</item>
+      <item>bar</item>
+      <item>col</item>
+      <item>area</item>
+      <item>tile</item>
+      <item>polygon</item>
+      <item>ribbon</item>
+      <item>histogram</item>
+      <item>density</item>
+      <item>smooth</item>
+      <item>boxplot</item>
+      <item>violin</item>
+      <item>text</item>
+      <item>label</item>
+      <item>segment</item>
+      <item>arrow</item>
+      <item>hline</item>
+      <item>vline</item>
+      <item>abline</item>
+      <item>errorbar</item>
+    </list>
+
+    <!-- Aesthetics -->
+    <list name="aesthetics">
+      <item>x</item>
+      <item>y</item>
+      <item>xmin</item>
+      <item>xmax</item>
+      <item>ymin</item>
+      <item>ymax</item>
+      <item>xend</item>
+      <item>yend</item>
+      <item>weight</item>
+      <item>color</item>
+      <item>colour</item>
+      <item>fill</item>
+      <item>stroke</item>
+      <item>opacity</item>
+      <item>size</item>
+      <item>shape</item>
+      <item>linetype</item>
+      <item>linewidth</item>
+      <item>width</item>
+      <item>height</item>
+      <item>family</item>
+      <item>fontface</item>
+      <item>hjust</item>
+      <item>vjust</item>
+    </list>
+
+    <!-- Scale Types (only in SCALE context) -->
+    <list name="scale_types">
+      <item>linear</item>
+      <item>log</item>
+      <item>log10</item>
+      <item>log2</item>
+      <item>sqrt</item>
+      <item>reverse</item>
+      <item>categorical</item>
+      <item>ordinal</item>
+      <item>date</item>
+      <item>datetime</item>
+      <item>time</item>
+      <item>viridis</item>
+      <item>plasma</item>
+      <item>magma</item>
+      <item>inferno</item>
+      <item>cividis</item>
+      <item>diverging</item>
+      <item>sequential</item>
+      <item>identity</item>
+      <item>manual</item>
+    </list>
+
+    <!-- Coordinate Types (only in COORD context) -->
+    <list name="coord_types">
+      <item>cartesian</item>
+      <item>polar</item>
+      <item>flip</item>
+      <item>fixed</item>
+      <item>trans</item>
+      <item>map</item>
+      <item>quickmap</item>
+    </list>
+
+    <!-- Theme Names (only in THEME context) -->
+    <list name="theme_names">
+      <item>minimal</item>
+      <item>classic</item>
+      <item>gray</item>
+      <item>grey</item>
+      <item>bw</item>
+      <item>dark</item>
+      <item>light</item>
+      <item>void</item>
+    </list>
+
+    <!-- Guide Types (only in GUIDE context) -->
+    <list name="guide_types">
+      <item>legend</item>
+      <item>colorbar</item>
+      <item>axis</item>
+      <item>none</item>
+    </list>
+
+    <!-- Facet Scales (only in FACET context) -->
+    <list name="facet_scales">
+      <item>fixed</item>
+      <item>free</item>
+      <item>free_x</item>
+      <item>free_y</item>
+    </list>
+
+    <!-- Scale Properties -->
+    <list name="scale_properties">
+      <item>type</item>
+      <item>limits</item>
+      <item>breaks</item>
+      <item>labels</item>
+      <item>expand</item>
+      <item>direction</item>
+      <item>na_value</item>
+      <item>palette</item>
+      <item>domain</item>
+      <item>range</item>
+    </list>
+
+    <!-- Coord Properties -->
+    <list name="coord_properties">
+      <item>xlim</item>
+      <item>ylim</item>
+      <item>ratio</item>
+      <item>theta</item>
+      <item>clip</item>
+    </list>
+
+    <!-- Label Properties -->
+    <list name="label_properties">
+      <item>title</item>
+      <item>subtitle</item>
+      <item>caption</item>
+      <item>tag</item>
+    </list>
+
+    <!-- Guide Properties -->
+    <list name="guide_properties">
+      <item>position</item>
+      <item>direction</item>
+      <item>nrow</item>
+      <item>ncol</item>
+      <item>title</item>
+      <item>title_position</item>
+      <item>label_position</item>
+      <item>text_angle</item>
+      <item>text_size</item>
+      <item>reverse</item>
+      <item>order</item>
+    </list>
+
+    <!-- Theme Properties -->
+    <list name="theme_properties">
+      <item>background</item>
+      <item>panel_background</item>
+      <item>panel_grid</item>
+      <item>panel_grid_major</item>
+      <item>panel_grid_minor</item>
+      <item>text_size</item>
+      <item>text_family</item>
+      <item>title_size</item>
+      <item>axis_text_size</item>
+      <item>axis_line</item>
+      <item>axis_line_width</item>
+      <item>panel_border</item>
+      <item>plot_margin</item>
+      <item>panel_spacing</item>
+      <item>legend_background</item>
+      <item>legend_position</item>
+      <item>legend_direction</item>
+    </list>
+
+    <!-- SQL Functions -->
+    <list name="sql_functions">
+      <item>count</item>
+      <item>sum</item>
+      <item>avg</item>
+      <item>min</item>
+      <item>max</item>
+      <item>stddev</item>
+      <item>variance</item>
+      <item>array_agg</item>
+      <item>string_agg</item>
+      <item>group_concat</item>
+      <item>row_number</item>
+      <item>rank</item>
+      <item>dense_rank</item>
+      <item>ntile</item>
+      <item>lag</item>
+      <item>lead</item>
+      <item>first_value</item>
+      <item>last_value</item>
+      <item>nth_value</item>
+      <item>cume_dist</item>
+      <item>percent_rank</item>
+      <item>date_trunc</item>
+      <item>date_part</item>
+      <item>datepart</item>
+      <item>datename</item>
+      <item>dateadd</item>
+      <item>datediff</item>
+      <item>extract</item>
+      <item>now</item>
+      <item>current_date</item>
+      <item>current_time</item>
+      <item>current_timestamp</item>
+      <item>getdate</item>
+      <item>getutcdate</item>
+      <item>strftime</item>
+      <item>strptime</item>
+      <item>make_date</item>
+      <item>make_time</item>
+      <item>make_timestamp</item>
+      <item>concat</item>
+      <item>substring</item>
+      <item>substr</item>
+      <item>length</item>
+      <item>len</item>
+      <item>char_length</item>
+      <item>lower</item>
+      <item>upper</item>
+      <item>trim</item>
+      <item>ltrim</item>
+      <item>rtrim</item>
+      <item>replace</item>
+      <item>lpad</item>
+      <item>rpad</item>
+      <item>split_part</item>
+      <item>string_split</item>
+      <item>format</item>
+      <item>printf</item>
+      <item>abs</item>
+      <item>ceil</item>
+      <item>ceiling</item>
+      <item>floor</item>
+      <item>round</item>
+      <item>trunc</item>
+      <item>truncate</item>
+      <item>mod</item>
+      <item>power</item>
+      <item>exp</item>
+      <item>ln</item>
+      <item>sign</item>
+      <item>sin</item>
+      <item>cos</item>
+      <item>tan</item>
+      <item>asin</item>
+      <item>acos</item>
+      <item>atan</item>
+      <item>atan2</item>
+      <item>pi</item>
+      <item>degrees</item>
+      <item>radians</item>
+      <item>random</item>
+      <item>rand</item>
+      <item>cast</item>
+      <item>convert</item>
+      <item>coalesce</item>
+      <item>nullif</item>
+      <item>ifnull</item>
+      <item>isnull</item>
+      <item>nvl</item>
+      <item>try_cast</item>
+      <item>typeof</item>
+      <item>greatest</item>
+      <item>least</item>
+      <item>decode</item>
+      <item>json</item>
+      <item>json_extract</item>
+      <item>json_value</item>
+      <item>json_query</item>
+      <item>json_object</item>
+      <item>json_array</item>
+      <item>to_json</item>
+      <item>from_json</item>
+      <item>unnest</item>
+      <item>generate_series</item>
+    </list>
+
+    <!-- Constants -->
+    <list name="constants">
+      <item>NULL</item>
+      <item>TRUE</item>
+      <item>FALSE</item>
+    </list>
+
+    <contexts>
+      <!-- Main context -->
+      <context name="Normal" attribute="Normal Text" lineEndContext="#stay">
+        <!-- Comments first -->
+        <Detect2Chars char="-" char1="-" attribute="Comment" context="Comment"/>
+        <Detect2Chars char="/" char1="*" attribute="Comment" context="CommentMulti" beginRegion="comment"/>
+
+        <!-- Strings -->
+        <DetectChar char="'" attribute="String" context="StringSingle"/>
+        <DetectChar char="&quot;" attribute="String" context="StringDouble"/>
+
+        <!-- Numbers -->
+        <RegExpr attribute="Number" context="#stay" String="-?[0-9]+\.?[0-9]*([eE][+-]?[0-9]+)?"/>
+
+        <!-- Clause keywords trigger context switches -->
+        <WordDetect attribute="Keyword" context="DrawClause" String="DRAW" insensitive="true"/>
+        <WordDetect attribute="Keyword" context="ScaleClause" String="SCALE" insensitive="true"/>
+        <WordDetect attribute="Keyword" context="CoordClause" String="COORD" insensitive="true"/>
+        <WordDetect attribute="Keyword" context="FacetClause" String="FACET" insensitive="true"/>
+        <WordDetect attribute="Keyword" context="LabelClause" String="LABEL" insensitive="true"/>
+        <WordDetect attribute="Keyword" context="GuideClause" String="GUIDE" insensitive="true"/>
+        <WordDetect attribute="Keyword" context="ThemeClause" String="THEME" insensitive="true"/>
+
+        <!-- Fat arrow operator -->
+        <StringDetect attribute="Operator" context="#stay" String="=&gt;"/>
+
+        <!-- SQL Keywords -->
+        <keyword attribute="Keyword" context="#stay" String="sql_keywords"/>
+
+        <!-- VISUALISE keyword - switch to VisualiseClause context -->
+        <WordDetect attribute="Keyword" context="VisualiseClause" String="VISUALISE" insensitive="true"/>
+        <WordDetect attribute="Keyword" context="VisualiseClause" String="VISUALIZE" insensitive="true"/>
+
+        <!-- Sub-keywords -->
+        <keyword attribute="Keyword" context="#stay" String="viz_subkeywords"/>
+
+        <!-- SQL Functions (followed by parenthesis) -->
+        <keyword attribute="Function" context="#stay" String="sql_functions"/>
+
+        <!-- Constants -->
+        <keyword attribute="Constant" context="#stay" String="constants"/>
+
+        <!-- Operators -->
+        <AnyChar attribute="Operator" context="#stay" String="=!&lt;&gt;+-*/%"/>
+        <DetectChar char="(" attribute="Symbol" context="#stay"/>
+        <DetectChar char=")" attribute="Symbol" context="#stay"/>
+        <DetectChar char="[" attribute="Symbol" context="#stay"/>
+        <DetectChar char="]" attribute="Symbol" context="#stay"/>
+        <DetectChar char="," attribute="Symbol" context="#stay"/>
+        <DetectChar char=";" attribute="Symbol" context="#stay"/>
+        <DetectChar char="." attribute="Symbol" context="#stay"/>
+        <Detect2Chars char=":" char1=":" attribute="Operator" context="#stay"/>
+      </context>
+
+      <!-- DRAW clause context -->
+      <context name="DrawClause" attribute="Normal Text" lineEndContext="#stay">
+        <Detect2Chars char="-" char1="-" attribute="Comment" context="Comment"/>
+        <Detect2Chars char="/" char1="*" attribute="Comment" context="CommentMulti" beginRegion="comment"/>
+        <DetectChar char="'" attribute="String" context="StringSingle"/>
+        <DetectChar char="&quot;" attribute="String" context="StringDouble"/>
+        <RegExpr attribute="Number" context="#stay" String="-?[0-9]+\.?[0-9]*([eE][+-]?[0-9]+)?"/>
+
+        <!-- Exit to other clause contexts -->
+        <WordDetect attribute="Keyword" context="DrawClause" String="DRAW" insensitive="true"/>
+        <WordDetect attribute="Keyword" context="ScaleClause" String="SCALE" insensitive="true"/>
+        <WordDetect attribute="Keyword" context="CoordClause" String="COORD" insensitive="true"/>
+        <WordDetect attribute="Keyword" context="FacetClause" String="FACET" insensitive="true"/>
+        <WordDetect attribute="Keyword" context="LabelClause" String="LABEL" insensitive="true"/>
+        <WordDetect attribute="Keyword" context="GuideClause" String="GUIDE" insensitive="true"/>
+        <WordDetect attribute="Keyword" context="ThemeClause" String="THEME" insensitive="true"/>
+        <WordDetect attribute="Keyword" context="Normal" String="VISUALISE" insensitive="true"/>
+        <WordDetect attribute="Keyword" context="Normal" String="VISUALIZE" insensitive="true"/>
+        <WordDetect attribute="Keyword" context="Normal" String="SELECT" insensitive="true"/>
+        <WordDetect attribute="Keyword" context="#stay" String="FROM" insensitive="true"/>
+        <WordDetect attribute="Keyword" context="Normal" String="WHERE" insensitive="true"/>
+        <WordDetect attribute="Keyword" context="Normal" String="WITH" insensitive="true"/>
+
+        <!-- Geom types - only highlighted here -->
+        <keyword attribute="Data Type" context="#stay" String="geoms"/>
+
+        <!-- Aesthetics -->
+        <keyword attribute="Attribute" context="#stay" String="aesthetics"/>
+
+        <!-- Sub-keywords -->
+        <keyword attribute="Keyword" context="#stay" String="viz_subkeywords"/>
+
+        <StringDetect attribute="Operator" context="#stay" String="=&gt;"/>
+        <AnyChar attribute="Operator" context="#stay" String="=!&lt;&gt;+-*/%"/>
+        <DetectChar char="(" attribute="Symbol" context="#stay"/>
+        <DetectChar char=")" attribute="Symbol" context="#stay"/>
+        <DetectChar char="[" attribute="Symbol" context="#stay"/>
+        <DetectChar char="]" attribute="Symbol" context="#stay"/>
+        <DetectChar char="," attribute="Symbol" context="#stay"/>
+      </context>
+
+      <!-- SCALE clause context -->
+      <context name="ScaleClause" attribute="Normal Text" lineEndContext="#stay">
+        <Detect2Chars char="-" char1="-" attribute="Comment" context="Comment"/>
+        <Detect2Chars char="/" char1="*" attribute="Comment" context="CommentMulti" beginRegion="comment"/>
+        <DetectChar char="'" attribute="String" context="StringSingle"/>
+        <DetectChar char="&quot;" attribute="String" context="StringDouble"/>
+        <RegExpr attribute="Number" context="#stay" String="-?[0-9]+\.?[0-9]*([eE][+-]?[0-9]+)?"/>
+
+        <!-- Exit to other clause contexts -->
+        <WordDetect attribute="Keyword" context="DrawClause" String="DRAW" insensitive="true"/>
+        <WordDetect attribute="Keyword" context="ScaleClause" String="SCALE" insensitive="true"/>
+        <WordDetect attribute="Keyword" context="CoordClause" String="COORD" insensitive="true"/>
+        <WordDetect attribute="Keyword" context="FacetClause" String="FACET" insensitive="true"/>
+        <WordDetect attribute="Keyword" context="LabelClause" String="LABEL" insensitive="true"/>
+        <WordDetect attribute="Keyword" context="GuideClause" String="GUIDE" insensitive="true"/>
+        <WordDetect attribute="Keyword" context="ThemeClause" String="THEME" insensitive="true"/>
+        <WordDetect attribute="Keyword" context="Normal" String="VISUALISE" insensitive="true"/>
+        <WordDetect attribute="Keyword" context="Normal" String="VISUALIZE" insensitive="true"/>
+        <WordDetect attribute="Keyword" context="Normal" String="SELECT" insensitive="true"/>
+        <WordDetect attribute="Keyword" context="#stay" String="FROM" insensitive="true"/>
+        <WordDetect attribute="Keyword" context="Normal" String="WHERE" insensitive="true"/>
+        <WordDetect attribute="Keyword" context="Normal" String="WITH" insensitive="true"/>
+
+        <!-- Scale types - only highlighted here -->
+        <keyword attribute="Data Type" context="#stay" String="scale_types"/>
+
+        <!-- Scale properties -->
+        <keyword attribute="Attribute" context="#stay" String="scale_properties"/>
+
+        <!-- Aesthetics (for scale aesthetic name) -->
+        <keyword attribute="Attribute" context="#stay" String="aesthetics"/>
+
+        <!-- Sub-keywords -->
+        <keyword attribute="Keyword" context="#stay" String="viz_subkeywords"/>
+
+        <StringDetect attribute="Operator" context="#stay" String="=&gt;"/>
+        <AnyChar attribute="Operator" context="#stay" String="=!&lt;&gt;+-*/%"/>
+        <DetectChar char="(" attribute="Symbol" context="#stay"/>
+        <DetectChar char=")" attribute="Symbol" context="#stay"/>
+        <DetectChar char="[" attribute="Symbol" context="#stay"/>
+        <DetectChar char="]" attribute="Symbol" context="#stay"/>
+        <DetectChar char="," attribute="Symbol" context="#stay"/>
+      </context>
+
+      <!-- COORD clause context -->
+      <context name="CoordClause" attribute="Normal Text" lineEndContext="#stay">
+        <Detect2Chars char="-" char1="-" attribute="Comment" context="Comment"/>
+        <Detect2Chars char="/" char1="*" attribute="Comment" context="CommentMulti" beginRegion="comment"/>
+        <DetectChar char="'" attribute="String" context="StringSingle"/>
+        <DetectChar char="&quot;" attribute="String" context="StringDouble"/>
+        <RegExpr attribute="Number" context="#stay" String="-?[0-9]+\.?[0-9]*([eE][+-]?[0-9]+)?"/>
+
+        <!-- Exit to other clause contexts -->
+        <WordDetect attribute="Keyword" context="DrawClause" String="DRAW" insensitive="true"/>
+        <WordDetect attribute="Keyword" context="ScaleClause" String="SCALE" insensitive="true"/>
+        <WordDetect attribute="Keyword" context="CoordClause" String="COORD" insensitive="true"/>
+        <WordDetect attribute="Keyword" context="FacetClause" String="FACET" insensitive="true"/>
+        <WordDetect attribute="Keyword" context="LabelClause" String="LABEL" insensitive="true"/>
+        <WordDetect attribute="Keyword" context="GuideClause" String="GUIDE" insensitive="true"/>
+        <WordDetect attribute="Keyword" context="ThemeClause" String="THEME" insensitive="true"/>
+        <WordDetect attribute="Keyword" context="Normal" String="VISUALISE" insensitive="true"/>
+        <WordDetect attribute="Keyword" context="Normal" String="VISUALIZE" insensitive="true"/>
+        <WordDetect attribute="Keyword" context="Normal" String="SELECT" insensitive="true"/>
+        <WordDetect attribute="Keyword" context="#stay" String="FROM" insensitive="true"/>
+        <WordDetect attribute="Keyword" context="Normal" String="WHERE" insensitive="true"/>
+        <WordDetect attribute="Keyword" context="Normal" String="WITH" insensitive="true"/>
+
+        <!-- Coord types - only highlighted here -->
+        <keyword attribute="Data Type" context="#stay" String="coord_types"/>
+
+        <!-- Coord properties -->
+        <keyword attribute="Attribute" context="#stay" String="coord_properties"/>
+
+        <!-- Aesthetics -->
+        <keyword attribute="Attribute" context="#stay" String="aesthetics"/>
+
+        <!-- Sub-keywords -->
+        <keyword attribute="Keyword" context="#stay" String="viz_subkeywords"/>
+
+        <StringDetect attribute="Operator" context="#stay" String="=&gt;"/>
+        <AnyChar attribute="Operator" context="#stay" String="=!&lt;&gt;+-*/%"/>
+        <DetectChar char="(" attribute="Symbol" context="#stay"/>
+        <DetectChar char=")" attribute="Symbol" context="#stay"/>
+        <DetectChar char="[" attribute="Symbol" context="#stay"/>
+        <DetectChar char="]" attribute="Symbol" context="#stay"/>
+        <DetectChar char="," attribute="Symbol" context="#stay"/>
+      </context>
+
+      <!-- FACET clause context -->
+      <context name="FacetClause" attribute="Normal Text" lineEndContext="#stay">
+        <Detect2Chars char="-" char1="-" attribute="Comment" context="Comment"/>
+        <Detect2Chars char="/" char1="*" attribute="Comment" context="CommentMulti" beginRegion="comment"/>
+        <DetectChar char="'" attribute="String" context="StringSingle"/>
+        <DetectChar char="&quot;" attribute="String" context="StringDouble"/>
+        <RegExpr attribute="Number" context="#stay" String="-?[0-9]+\.?[0-9]*([eE][+-]?[0-9]+)?"/>
+
+        <!-- Exit to other clause contexts -->
+        <WordDetect attribute="Keyword" context="DrawClause" String="DRAW" insensitive="true"/>
+        <WordDetect attribute="Keyword" context="ScaleClause" String="SCALE" insensitive="true"/>
+        <WordDetect attribute="Keyword" context="CoordClause" String="COORD" insensitive="true"/>
+        <WordDetect attribute="Keyword" context="FacetClause" String="FACET" insensitive="true"/>
+        <WordDetect attribute="Keyword" context="LabelClause" String="LABEL" insensitive="true"/>
+        <WordDetect attribute="Keyword" context="GuideClause" String="GUIDE" insensitive="true"/>
+        <WordDetect attribute="Keyword" context="ThemeClause" String="THEME" insensitive="true"/>
+        <WordDetect attribute="Keyword" context="Normal" String="VISUALISE" insensitive="true"/>
+        <WordDetect attribute="Keyword" context="Normal" String="VISUALIZE" insensitive="true"/>
+        <WordDetect attribute="Keyword" context="Normal" String="SELECT" insensitive="true"/>
+        <WordDetect attribute="Keyword" context="#stay" String="FROM" insensitive="true"/>
+        <WordDetect attribute="Keyword" context="Normal" String="WHERE" insensitive="true"/>
+        <WordDetect attribute="Keyword" context="Normal" String="WITH" insensitive="true"/>
+
+        <!-- Facet scales - only highlighted here -->
+        <keyword attribute="Data Type" context="#stay" String="facet_scales"/>
+
+        <!-- WRAP keyword -->
+        <WordDetect attribute="Keyword" context="#stay" String="WRAP" insensitive="true"/>
+
+        <!-- scales property -->
+        <WordDetect attribute="Attribute" context="#stay" String="scales" insensitive="true"/>
+
+        <!-- Sub-keywords -->
+        <keyword attribute="Keyword" context="#stay" String="viz_subkeywords"/>
+
+        <StringDetect attribute="Operator" context="#stay" String="=&gt;"/>
+        <AnyChar attribute="Operator" context="#stay" String="=!&lt;&gt;+-*/%"/>
+        <DetectChar char="(" attribute="Symbol" context="#stay"/>
+        <DetectChar char=")" attribute="Symbol" context="#stay"/>
+        <DetectChar char="[" attribute="Symbol" context="#stay"/>
+        <DetectChar char="]" attribute="Symbol" context="#stay"/>
+        <DetectChar char="," attribute="Symbol" context="#stay"/>
+      </context>
+
+      <!-- LABEL clause context -->
+      <context name="LabelClause" attribute="Normal Text" lineEndContext="#stay">
+        <Detect2Chars char="-" char1="-" attribute="Comment" context="Comment"/>
+        <Detect2Chars char="/" char1="*" attribute="Comment" context="CommentMulti" beginRegion="comment"/>
+        <DetectChar char="'" attribute="String" context="StringSingle"/>
+        <DetectChar char="&quot;" attribute="String" context="StringDouble"/>
+        <RegExpr attribute="Number" context="#stay" String="-?[0-9]+\.?[0-9]*([eE][+-]?[0-9]+)?"/>
+
+        <!-- Exit to other clause contexts -->
+        <WordDetect attribute="Keyword" context="DrawClause" String="DRAW" insensitive="true"/>
+        <WordDetect attribute="Keyword" context="ScaleClause" String="SCALE" insensitive="true"/>
+        <WordDetect attribute="Keyword" context="CoordClause" String="COORD" insensitive="true"/>
+        <WordDetect attribute="Keyword" context="FacetClause" String="FACET" insensitive="true"/>
+        <WordDetect attribute="Keyword" context="LabelClause" String="LABEL" insensitive="true"/>
+        <WordDetect attribute="Keyword" context="GuideClause" String="GUIDE" insensitive="true"/>
+        <WordDetect attribute="Keyword" context="ThemeClause" String="THEME" insensitive="true"/>
+        <WordDetect attribute="Keyword" context="Normal" String="VISUALISE" insensitive="true"/>
+        <WordDetect attribute="Keyword" context="Normal" String="VISUALIZE" insensitive="true"/>
+        <WordDetect attribute="Keyword" context="Normal" String="SELECT" insensitive="true"/>
+        <WordDetect attribute="Keyword" context="#stay" String="FROM" insensitive="true"/>
+        <WordDetect attribute="Keyword" context="Normal" String="WHERE" insensitive="true"/>
+        <WordDetect attribute="Keyword" context="Normal" String="WITH" insensitive="true"/>
+
+        <!-- Label properties -->
+        <keyword attribute="Attribute" context="#stay" String="label_properties"/>
+
+        <!-- Aesthetics (for legend labels) -->
+        <keyword attribute="Attribute" context="#stay" String="aesthetics"/>
+
+        <StringDetect attribute="Operator" context="#stay" String="=&gt;"/>
+        <AnyChar attribute="Operator" context="#stay" String="=!&lt;&gt;+-*/%"/>
+        <DetectChar char="(" attribute="Symbol" context="#stay"/>
+        <DetectChar char=")" attribute="Symbol" context="#stay"/>
+        <DetectChar char="[" attribute="Symbol" context="#stay"/>
+        <DetectChar char="]" attribute="Symbol" context="#stay"/>
+        <DetectChar char="," attribute="Symbol" context="#stay"/>
+      </context>
+
+      <!-- GUIDE clause context -->
+      <context name="GuideClause" attribute="Normal Text" lineEndContext="#stay">
+        <Detect2Chars char="-" char1="-" attribute="Comment" context="Comment"/>
+        <Detect2Chars char="/" char1="*" attribute="Comment" context="CommentMulti" beginRegion="comment"/>
+        <DetectChar char="'" attribute="String" context="StringSingle"/>
+        <DetectChar char="&quot;" attribute="String" context="StringDouble"/>
+        <RegExpr attribute="Number" context="#stay" String="-?[0-9]+\.?[0-9]*([eE][+-]?[0-9]+)?"/>
+
+        <!-- Exit to other clause contexts -->
+        <WordDetect attribute="Keyword" context="DrawClause" String="DRAW" insensitive="true"/>
+        <WordDetect attribute="Keyword" context="ScaleClause" String="SCALE" insensitive="true"/>
+        <WordDetect attribute="Keyword" context="CoordClause" String="COORD" insensitive="true"/>
+        <WordDetect attribute="Keyword" context="FacetClause" String="FACET" insensitive="true"/>
+        <WordDetect attribute="Keyword" context="LabelClause" String="LABEL" insensitive="true"/>
+        <WordDetect attribute="Keyword" context="GuideClause" String="GUIDE" insensitive="true"/>
+        <WordDetect attribute="Keyword" context="ThemeClause" String="THEME" insensitive="true"/>
+        <WordDetect attribute="Keyword" context="Normal" String="VISUALISE" insensitive="true"/>
+        <WordDetect attribute="Keyword" context="Normal" String="VISUALIZE" insensitive="true"/>
+        <WordDetect attribute="Keyword" context="Normal" String="SELECT" insensitive="true"/>
+        <WordDetect attribute="Keyword" context="#stay" String="FROM" insensitive="true"/>
+        <WordDetect attribute="Keyword" context="Normal" String="WHERE" insensitive="true"/>
+        <WordDetect attribute="Keyword" context="Normal" String="WITH" insensitive="true"/>
+
+        <!-- Guide types - only highlighted here -->
+        <keyword attribute="Data Type" context="#stay" String="guide_types"/>
+
+        <!-- Guide properties -->
+        <keyword attribute="Attribute" context="#stay" String="guide_properties"/>
+
+        <!-- Aesthetics -->
+        <keyword attribute="Attribute" context="#stay" String="aesthetics"/>
+
+        <!-- Sub-keywords -->
+        <keyword attribute="Keyword" context="#stay" String="viz_subkeywords"/>
+
+        <StringDetect attribute="Operator" context="#stay" String="=&gt;"/>
+        <AnyChar attribute="Operator" context="#stay" String="=!&lt;&gt;+-*/%"/>
+        <DetectChar char="(" attribute="Symbol" context="#stay"/>
+        <DetectChar char=")" attribute="Symbol" context="#stay"/>
+        <DetectChar char="[" attribute="Symbol" context="#stay"/>
+        <DetectChar char="]" attribute="Symbol" context="#stay"/>
+        <DetectChar char="," attribute="Symbol" context="#stay"/>
+      </context>
+
+      <!-- THEME clause context -->
+      <context name="ThemeClause" attribute="Normal Text" lineEndContext="#stay">
+        <Detect2Chars char="-" char1="-" attribute="Comment" context="Comment"/>
+        <Detect2Chars char="/" char1="*" attribute="Comment" context="CommentMulti" beginRegion="comment"/>
+        <DetectChar char="'" attribute="String" context="StringSingle"/>
+        <DetectChar char="&quot;" attribute="String" context="StringDouble"/>
+        <RegExpr attribute="Number" context="#stay" String="-?[0-9]+\.?[0-9]*([eE][+-]?[0-9]+)?"/>
+
+        <!-- Exit to other clause contexts -->
+        <WordDetect attribute="Keyword" context="DrawClause" String="DRAW" insensitive="true"/>
+        <WordDetect attribute="Keyword" context="ScaleClause" String="SCALE" insensitive="true"/>
+        <WordDetect attribute="Keyword" context="CoordClause" String="COORD" insensitive="true"/>
+        <WordDetect attribute="Keyword" context="FacetClause" String="FACET" insensitive="true"/>
+        <WordDetect attribute="Keyword" context="LabelClause" String="LABEL" insensitive="true"/>
+        <WordDetect attribute="Keyword" context="GuideClause" String="GUIDE" insensitive="true"/>
+        <WordDetect attribute="Keyword" context="ThemeClause" String="THEME" insensitive="true"/>
+        <WordDetect attribute="Keyword" context="Normal" String="VISUALISE" insensitive="true"/>
+        <WordDetect attribute="Keyword" context="Normal" String="VISUALIZE" insensitive="true"/>
+        <WordDetect attribute="Keyword" context="Normal" String="SELECT" insensitive="true"/>
+        <WordDetect attribute="Keyword" context="#stay" String="FROM" insensitive="true"/>
+        <WordDetect attribute="Keyword" context="Normal" String="WHERE" insensitive="true"/>
+        <WordDetect attribute="Keyword" context="Normal" String="WITH" insensitive="true"/>
+
+        <!-- Theme names - only highlighted here -->
+        <keyword attribute="Data Type" context="#stay" String="theme_names"/>
+
+        <!-- Theme properties -->
+        <keyword attribute="Attribute" context="#stay" String="theme_properties"/>
+
+        <!-- Sub-keywords -->
+        <keyword attribute="Keyword" context="#stay" String="viz_subkeywords"/>
+
+        <StringDetect attribute="Operator" context="#stay" String="=&gt;"/>
+        <AnyChar attribute="Operator" context="#stay" String="=!&lt;&gt;+-*/%"/>
+        <DetectChar char="(" attribute="Symbol" context="#stay"/>
+        <DetectChar char=")" attribute="Symbol" context="#stay"/>
+        <DetectChar char="[" attribute="Symbol" context="#stay"/>
+        <DetectChar char="]" attribute="Symbol" context="#stay"/>
+        <DetectChar char="," attribute="Symbol" context="#stay"/>
+      </context>
+
+      <!-- VISUALISE clause context -->
+      <context name="VisualiseClause" attribute="Normal Text" lineEndContext="#stay">
+        <Detect2Chars char="-" char1="-" attribute="Comment" context="Comment"/>
+        <Detect2Chars char="/" char1="*" attribute="Comment" context="CommentMulti" beginRegion="comment"/>
+        <DetectChar char="'" attribute="String" context="StringSingle"/>
+        <DetectChar char="&quot;" attribute="String" context="StringDouble"/>
+        <RegExpr attribute="Number" context="#stay" String="-?[0-9]+\.?[0-9]*([eE][+-]?[0-9]+)?"/>
+
+        <!-- Exit to other clause contexts -->
+        <WordDetect attribute="Keyword" context="DrawClause" String="DRAW" insensitive="true"/>
+        <WordDetect attribute="Keyword" context="ScaleClause" String="SCALE" insensitive="true"/>
+        <WordDetect attribute="Keyword" context="CoordClause" String="COORD" insensitive="true"/>
+        <WordDetect attribute="Keyword" context="FacetClause" String="FACET" insensitive="true"/>
+        <WordDetect attribute="Keyword" context="LabelClause" String="LABEL" insensitive="true"/>
+        <WordDetect attribute="Keyword" context="GuideClause" String="GUIDE" insensitive="true"/>
+        <WordDetect attribute="Keyword" context="ThemeClause" String="THEME" insensitive="true"/>
+        <WordDetect attribute="Keyword" context="VisualiseClause" String="VISUALISE" insensitive="true"/>
+        <WordDetect attribute="Keyword" context="VisualiseClause" String="VISUALIZE" insensitive="true"/>
+        <WordDetect attribute="Keyword" context="Normal" String="SELECT" insensitive="true"/>
+        <WordDetect attribute="Keyword" context="#stay" String="FROM" insensitive="true"/>
+        <WordDetect attribute="Keyword" context="Normal" String="WHERE" insensitive="true"/>
+        <WordDetect attribute="Keyword" context="Normal" String="WITH" insensitive="true"/>
+
+        <!-- Aesthetics - highlighted after VISUALISE -->
+        <keyword attribute="Attribute" context="#stay" String="aesthetics"/>
+
+        <!-- AS, FROM, FILTER keywords -->
+        <WordDetect attribute="Keyword" context="#stay" String="AS" insensitive="true"/>
+        <WordDetect attribute="Keyword" context="#stay" String="FILTER" insensitive="true"/>
+
+        <!-- Wildcard -->
+        <DetectChar char="*" attribute="Operator" context="#stay"/>
+
+        <StringDetect attribute="Operator" context="#stay" String="=&gt;"/>
+        <AnyChar attribute="Operator" context="#stay" String="=!&lt;&gt;+-*/%"/>
+        <DetectChar char="(" attribute="Symbol" context="#stay"/>
+        <DetectChar char=")" attribute="Symbol" context="#stay"/>
+        <DetectChar char="[" attribute="Symbol" context="#stay"/>
+        <DetectChar char="]" attribute="Symbol" context="#stay"/>
+        <DetectChar char="," attribute="Symbol" context="#stay"/>
+      </context>
+
+      <!-- Single-quoted string -->
+      <context name="StringSingle" attribute="String" lineEndContext="#stay">
+        <DetectChar char="'" attribute="String" context="#pop"/>
+        <Detect2Chars char="'" char1="'" attribute="String" context="#stay"/>
+        <RegExpr attribute="Special Character" context="#stay" String="\\." />
+      </context>
+
+      <!-- Double-quoted string/identifier -->
+      <context name="StringDouble" attribute="String" lineEndContext="#stay">
+        <DetectChar char="&quot;" attribute="String" context="#pop"/>
+        <Detect2Chars char="&quot;" char1="&quot;" attribute="String" context="#stay"/>
+        <RegExpr attribute="Special Character" context="#stay" String="\\." />
+      </context>
+
+      <!-- Single-line comment -->
+      <context name="Comment" attribute="Comment" lineEndContext="#pop">
+        <DetectSpaces/>
+        <IncludeRules context="##Comments"/>
+      </context>
+
+      <!-- Multi-line comment -->
+      <context name="CommentMulti" attribute="Comment" lineEndContext="#stay">
+        <Detect2Chars char="*" char1="/" attribute="Comment" context="#pop" endRegion="comment"/>
+        <IncludeRules context="##Comments"/>
+      </context>
+    </contexts>
+
+    <itemDatas>
+      <itemData name="Normal Text"      defStyleNum="dsNormal"/>
+      <itemData name="Keyword"          defStyleNum="dsKeyword"/>
+      <itemData name="Function"         defStyleNum="dsFunction"/>
+      <itemData name="Data Type"        defStyleNum="dsDataType"/>
+      <itemData name="Attribute"        defStyleNum="dsAttribute"/>
+      <itemData name="String"           defStyleNum="dsString"/>
+      <itemData name="Special Character" defStyleNum="dsSpecialChar"/>
+      <itemData name="Number"           defStyleNum="dsDecVal"/>
+      <itemData name="Constant"         defStyleNum="dsConstant"/>
+      <itemData name="Comment"          defStyleNum="dsComment"/>
+      <itemData name="Operator"         defStyleNum="dsOperator"/>
+      <itemData name="Symbol"           defStyleNum="dsNormal"/>
+    </itemDatas>
+  </highlighting>
+
+  <general>
+    <comments>
+      <comment name="singleLine" start="--"/>
+      <comment name="multiLine" start="/*" end="*/" region="comment"/>
+    </comments>
+    <keywords casesensitive="0" weakDeliminator="_"/>
+  </general>
+</language>

--- a/doc/index.qmd
+++ b/doc/index.qmd
@@ -31,7 +31,7 @@ A declarative visualization language that extends SQL with powerful data visuali
 
 Write standard SQL queries and seamlessly extend them with visualization clauses. Your existing SQL knowledge transfers directly.
 
-```{.sql .code-example}
+```{.ggsql .code-example}
 SELECT date, revenue, region
 FROM sales
 WHERE year = 2024
@@ -45,11 +45,11 @@ DRAW line
 
 Compose visualizations from independent layers, scales, and coordinates. Mix and match geoms, facets, and themes for precise control.
 
-```{.sql .code-example}
+```{.ggsql .code-example}
 DRAW line 
-    MAPPING x AS date, y AS value
+    MAPPING date AS x, value AS y
 DRAW point 
-    MAPPING x AS date, y AS value
+    MAPPING date AS x, value AS y
 SCALE x 
     SETTING type => 'date'
 FACET WRAP region
@@ -61,7 +61,7 @@ FACET WRAP region
 
 Connect to DuckDB, PostgreSQL, or SQLite. Output to Vega-Lite, ggplot2, or render directly to PNG.
 
-```{.sql .code-example}
+```{.ggsql .code-example}
 -- Use any data source
 ggsql exec "SELECT ..."
   --reader duckdb://data.db
@@ -127,7 +127,7 @@ Parse, validate, and execute queries from the command line. Perfect for automati
 ::: {.example-container}
 
 ::: {.example-code}
-```{.sql}
+```{.ggsql}
 -- Create a multi-layer visualization
 SELECT date, revenue, region
 FROM sales

--- a/ggsql-vscode/syntaxes/ggsql.tmLanguage.json
+++ b/ggsql-vscode/syntaxes/ggsql.tmLanguage.json
@@ -6,8 +6,16 @@
     { "include": "#comments" },
     { "include": "#strings" },
     { "include": "#numbers" },
-    { "include": "#visualise-statement" },
+    { "include": "#sql-functions" },
+    { "include": "#draw-clause" },
+    { "include": "#scale-clause" },
+    { "include": "#facet-clause" },
+    { "include": "#coord-clause" },
+    { "include": "#label-clause" },
+    { "include": "#guide-clause" },
+    { "include": "#theme-clause" },
     { "include": "#sql-keywords" },
+    { "include": "#visualise-clause" },
     { "include": "#operators" }
   ],
   "repository": {
@@ -61,16 +69,20 @@
     "operators": {
       "patterns": [
         {
-          "name": "keyword.operator.comparison.ggsql",
-          "match": "<=|>=|<>|<|>|="
+          "name": "keyword.operator.fatarrow.ggsql",
+          "match": "=>"
         },
         {
-          "name": "keyword.operator.logical.ggsql",
-          "match": "\\b(?i:AND|OR|NOT|IN|BETWEEN|LIKE|EXISTS)\\b"
+          "name": "keyword.operator.comparison.ggsql",
+          "match": "<=|>=|<>|!=|<|>|="
         },
         {
           "name": "keyword.operator.arithmetic.ggsql",
-          "match": "\\+|-|\\*|/|%"
+          "match": "\\+|-|\\*|/|%|\\|\\|"
+        },
+        {
+          "name": "keyword.operator.cast.ggsql",
+          "match": "::"
         },
         {
           "name": "punctuation.separator.comma.ggsql",
@@ -86,43 +98,114 @@
         }
       ]
     },
+    "sql-functions": {
+      "patterns": [
+        {
+          "comment": "Aggregate functions",
+          "match": "(?i)\\b(count|sum|avg|min|max|stddev|variance|array_agg|string_agg|group_concat)\\b\\s*\\(",
+          "captures": {
+            "1": { "name": "support.function.aggregate.sql" }
+          }
+        },
+        {
+          "comment": "Window/ranking functions",
+          "match": "(?i)\\b(row_number|rank|dense_rank|ntile|lag|lead|first_value|last_value|nth_value|cume_dist|percent_rank)\\b\\s*\\(",
+          "captures": {
+            "1": { "name": "support.function.window.sql" }
+          }
+        },
+        {
+          "comment": "DateTime functions",
+          "match": "(?i)\\b(date_trunc|date_part|datepart|datename|dateadd|datediff|extract|now|current_date|current_time|current_timestamp|getdate|getutcdate|strftime|strptime|make_date|make_time|make_timestamp)\\b\\s*\\(",
+          "captures": {
+            "1": { "name": "support.function.datetime.sql" }
+          }
+        },
+        {
+          "comment": "String functions",
+          "match": "(?i)\\b(concat|substring|substr|left|right|length|len|char_length|lower|upper|trim|ltrim|rtrim|replace|reverse|repeat|lpad|rpad|split_part|string_split|format|printf|regexp_replace|regexp_extract|regexp_matches)\\b\\s*\\(",
+          "captures": {
+            "1": { "name": "support.function.string.sql" }
+          }
+        },
+        {
+          "comment": "Mathematical functions",
+          "match": "(?i)\\b(abs|ceil|ceiling|floor|round|trunc|truncate|mod|power|sqrt|exp|ln|log|log10|log2|sign|sin|cos|tan|asin|acos|atan|atan2|pi|degrees|radians|random|rand)\\b\\s*\\(",
+          "captures": {
+            "1": { "name": "support.function.math.sql" }
+          }
+        },
+        {
+          "comment": "Conversion/type functions",
+          "match": "(?i)\\b(cast|convert|coalesce|nullif|ifnull|isnull|nvl|try_cast|typeof)\\b\\s*\\(",
+          "captures": {
+            "1": { "name": "support.function.conversion.sql" }
+          }
+        },
+        {
+          "comment": "Conditional functions",
+          "match": "(?i)\\b(if|iff|iif|greatest|least|decode)\\b\\s*\\(",
+          "captures": {
+            "1": { "name": "support.function.conditional.sql" }
+          }
+        },
+        {
+          "comment": "JSON functions",
+          "match": "(?i)\\b(json|json_extract|json_extract_path|json_extract_string|json_value|json_query|json_object|json_array|json_array_length|to_json|from_json)\\b\\s*\\(",
+          "captures": {
+            "1": { "name": "support.function.json.sql" }
+          }
+        },
+        {
+          "comment": "List/array functions",
+          "match": "(?i)\\b(list|list_value|list_aggregate|array_length|unnest|generate_series|range)\\b\\s*\\(",
+          "captures": {
+            "1": { "name": "support.function.array.sql" }
+          }
+        }
+      ]
+    },
     "sql-keywords": {
       "patterns": [
         {
-          "name": "keyword.other.sql.select.ggsql",
-          "match": "\\b(?i:SELECT|FROM|WHERE|GROUP BY|ORDER BY|HAVING|LIMIT|OFFSET|DISTINCT|ALL)\\b"
+          "name": "keyword.other.ggsql",
+          "match": "\\b(?i:SELECT|FROM|WHERE|GROUP|ORDER|BY|HAVING|LIMIT|OFFSET|DISTINCT|ALL)\\b"
         },
         {
-          "name": "keyword.other.sql.join.ggsql",
-          "match": "\\b(?i:JOIN|LEFT JOIN|RIGHT JOIN|INNER JOIN|OUTER JOIN|CROSS JOIN|LATERAL|ON)\\b"
+          "name": "keyword.other.ggsql",
+          "match": "\\b(?i:JOIN|LEFT|RIGHT|INNER|OUTER|CROSS|FULL|NATURAL|LATERAL|ON)\\b"
         },
         {
-          "name": "keyword.other.sql.cte.ggsql",
+          "name": "keyword.other.ggsql",
           "match": "\\b(?i:WITH|RECURSIVE|AS)\\b"
         },
         {
-          "name": "keyword.other.sql.dml.ggsql",
+          "name": "keyword.other.ggsql",
           "match": "\\b(?i:INSERT|UPDATE|DELETE|CREATE|DROP|ALTER|TRUNCATE|INTO|VALUES|SET)\\b"
         },
         {
-          "name": "keyword.other.sql.ddl.ggsql",
+          "name": "keyword.other.ggsql",
           "match": "\\b(?i:TABLE|VIEW|INDEX|DATABASE|SCHEMA|TEMP|TEMPORARY)\\b"
         },
         {
-          "name": "keyword.other.sql.aggregate.ggsql",
-          "match": "\\b(?i:COUNT|SUM|AVG|MIN|MAX|STDDEV|VARIANCE)\\b"
+          "name": "keyword.other.ggsql",
+          "match": "\\b(?i:CASE|WHEN|THEN|ELSE|END)\\b"
         },
         {
-          "name": "keyword.other.sql.function.ggsql",
-          "match": "\\b(?i:DATE_TRUNC|EXTRACT|CAST|COALESCE|NULLIF|CASE|WHEN|THEN|ELSE|END)\\b"
+          "name": "keyword.other.ggsql",
+          "match": "\\b(?i:OVER|PARTITION|ROWS|RANGE|UNBOUNDED|PRECEDING|FOLLOWING|CURRENT|ROW|NULLS|FIRST|LAST)\\b"
         },
         {
-          "name": "keyword.other.sql.window.ggsql",
-          "match": "\\b(?i:OVER|PARTITION BY|ROW_NUMBER|RANK|DENSE_RANK|LAG|LEAD)\\b"
-        },
-        {
-          "name": "keyword.other.sql.setop.ggsql",
+          "name": "keyword.other.ggsql",
           "match": "\\b(?i:UNION|INTERSECT|EXCEPT)\\b"
+        },
+        {
+          "name": "keyword.other.ggsql",
+          "match": "\\b(?i:AND|OR|NOT|IN|BETWEEN|LIKE|ILIKE|EXISTS|IS|ANY)\\b"
+        },
+        {
+          "name": "keyword.other.ggsql",
+          "match": "\\b(?i:ASC|DESC)\\b"
         },
         {
           "name": "constant.language.null.ggsql",
@@ -130,187 +213,195 @@
         }
       ]
     },
-    "visualise-statement": {
+    "visualise-clause": {
+      "begin": "(?i)\\b(VISUALISE|VISUALIZE)\\b",
+      "beginCaptures": {
+        "1": { "name": "keyword.other.ggsql" }
+      },
+      "end": "(?i)(?=\\b(DRAW|SCALE|COORD|FACET|LABEL|GUIDE|THEME|VISUALISE|VISUALIZE|SELECT|WHERE|WITH)\\b)",
+      "patterns": [
+        { "include": "#comments" },
+        { "include": "#strings" },
+        { "include": "#numbers" },
+        { "include": "#aesthetics" },
+        {
+          "name": "keyword.other.ggsql",
+          "match": "\\b(?i:AS|FROM|FILTER)\\b"
+        },
+        {
+          "name": "keyword.operator.fatarrow.ggsql",
+          "match": "=>"
+        },
+        {
+          "name": "punctuation.separator.comma.ggsql",
+          "match": ","
+        },
+        {
+          "name": "punctuation.bracket.round.ggsql",
+          "match": "\\(|\\)"
+        },
+        {
+          "name": "keyword.operator.wildcard.ggsql",
+          "match": "\\*"
+        }
+      ]
+    },
+    "aesthetics": {
       "patterns": [
         {
-          "name": "keyword.control.visualise.ggsql",
-          "match": "\\b(?i:VISUALISE|VISUALIZE)\\b"
+          "name": "support.type.aesthetic.ggsql",
+          "match": "\\b(x|y|xmin|xmax|ymin|ymax|xend|yend|weight|color|colour|fill|stroke|opacity|size|shape|linetype|linewidth|width|height|label|family|fontface|hjust|vjust)\\b"
+        }
+      ]
+    },
+    "common-clause-patterns": {
+      "patterns": [
+        { "include": "#comments" },
+        { "include": "#strings" },
+        { "include": "#numbers" },
+        { "include": "#aesthetics" },
+        {
+          "name": "keyword.operator.fatarrow.ggsql",
+          "match": "=>"
         },
         {
-          "name": "constant.language.viz-type.ggsql",
-          "match": "\\b(?i:PLOT|TABLE|MAP)\\b"
+          "name": "keyword.other.ggsql",
+          "match": "\\b(?i:MAPPING|REMAPPING|SETTING|FILTER|FROM|ORDER|BY|PARTITION)\\b"
         },
-        { "include": "#draw-clause" },
-        { "include": "#scale-clause" },
-        { "include": "#facet-clause" },
-        { "include": "#coord-clause" },
-        { "include": "#label-clause" },
-        { "include": "#guide-clause" },
-        { "include": "#theme-clause" }
+        {
+          "name": "punctuation.separator.comma.ggsql",
+          "match": ","
+        },
+        {
+          "name": "punctuation.bracket.square.ggsql",
+          "match": "\\[|\\]"
+        },
+        {
+          "name": "punctuation.bracket.round.ggsql",
+          "match": "\\(|\\)"
+        }
       ]
     },
     "draw-clause": {
+      "begin": "(?i)\\b(DRAW)\\b",
+      "beginCaptures": {
+        "1": { "name": "keyword.other.ggsql" }
+      },
+      "end": "(?i)(?=\\b(DRAW|SCALE|COORD|FACET|LABEL|GUIDE|THEME|VISUALISE|VISUALIZE|SELECT|WHERE|WITH)\\b)",
       "patterns": [
-        {
-          "name": "keyword.control.visualise.ggsql",
-          "match": "\\b(?i:DRAW)\\b"
-        },
-        {
-          "name": "keyword.control.mapping.ggsql",
-          "match": "\\b(?i:MAPPING)\\b"
-        },
-        {
-          "name": "keyword.control.setting.ggsql",
-          "match": "\\b(?i:SETTING)\\b"
-        },
-        {
-          "name": "keyword.control.fatarrow.ggsql",
-          "match": "(?<!\\S)=>(?!\\S)"
-        },
-        {
-          "name": "keyword.control.filter.ggsql",
-          "match": "\\b(?i:FILTER)\\b"
-        },
         {
           "name": "support.type.geom.ggsql",
           "match": "\\b(point|line|path|bar|col|area|tile|polygon|ribbon|histogram|density|smooth|boxplot|violin|text|label|segment|arrow|hline|vline|abline|errorbar)\\b"
         },
-        {
-          "name": "variable.parameter.aesthetic.ggsql",
-          "match": "\\b(x|y|xmin|xmax|ymin|ymax|xend|yend|color|colour|fill|stroke|opacity|size|shape|linetype|linewidth|width|height|label|family|fontface|hjust|vjust)\\b"
-        }
+        { "include": "#common-clause-patterns" }
       ]
     },
     "scale-clause": {
+      "begin": "(?i)\\b(SCALE)\\b",
+      "beginCaptures": {
+        "1": { "name": "keyword.other.ggsql" }
+      },
+      "end": "(?i)(?=\\b(DRAW|SCALE|COORD|FACET|LABEL|GUIDE|THEME|VISUALISE|VISUALIZE|SELECT|WHERE|WITH)\\b)",
       "patterns": [
         {
-          "name": "keyword.control.scale.ggsql",
-          "match": "\\b(?i:SCALE)\\b"
+          "name": "constant.language.scale-type.ggsql",
+          "match": "\\b(linear|log|log10|log2|sqrt|reverse|categorical|ordinal|date|datetime|time|viridis|plasma|magma|inferno|cividis|diverging|sequential|identity|manual)\\b"
         },
         {
-          "name": "keyword.control.setting.ggsql",
-          "match": "\\b(?i:SETTING)\\b"
-        },
-        {
-          "name": "keyword.control.fatarrow.ggsql",
-          "match": "(?<!\\S)=>(?!\\S)"
-        },
-        {
-          "name": "variable.parameter.scale-property.ggsql",
+          "name": "support.type.property.ggsql",
           "match": "\\b(type|limits|breaks|labels|expand|direction|na_value|palette|domain|range)\\b"
         },
-        {
-          "name": "constant.language.scale-type.ggsql",
-          "match": "\\b(linear|log|log10|log2|sqrt|reverse|categorical|ordinal|date|datetime|time|viridis|plasma|magma|inferno|diverging)\\b"
-        }
+        { "include": "#common-clause-patterns" }
       ]
     },
     "facet-clause": {
+      "begin": "(?i)\\b(FACET)\\b",
+      "beginCaptures": {
+        "1": { "name": "keyword.other.ggsql" }
+      },
+      "end": "(?i)(?=\\b(DRAW|SCALE|COORD|FACET|LABEL|GUIDE|THEME|VISUALISE|VISUALIZE|SELECT|WHERE|WITH)\\b)",
       "patterns": [
         {
-          "name": "keyword.control.facet.ggsql",
-          "match": "\\b(?i:FACET|WRAP|BY)\\b"
-        },
-        {
-          "name": "keyword.control.setting.ggsql",
-          "match": "\\b(?i:SETTING)\\b"
-        },
-        {
-          "name": "keyword.control.fatarrow.ggsql",
-          "match": "(?<!\\S)=>(?!\\S)"
+          "name": "keyword.other.ggsql",
+          "match": "\\b(?i:WRAP)\\b"
         },
         {
           "name": "constant.language.facet-scales.ggsql",
           "match": "\\b(fixed|free|free_x|free_y)\\b"
         },
         {
-          "name": "variable.parameter.facet-property.ggsql",
+          "name": "support.type.property.ggsql",
           "match": "\\b(scales)\\b"
-        }
+        },
+        { "include": "#common-clause-patterns" }
       ]
     },
     "coord-clause": {
+      "begin": "(?i)\\b(COORD)\\b",
+      "beginCaptures": {
+        "1": { "name": "keyword.other.ggsql" }
+      },
+      "end": "(?i)(?=\\b(DRAW|SCALE|COORD|FACET|LABEL|GUIDE|THEME|VISUALISE|VISUALIZE|SELECT|WHERE|WITH)\\b)",
       "patterns": [
         {
-          "name": "keyword.control.coord.ggsql",
-          "match": "\\b(?i:COORD)\\b"
-        },
-        {
-          "name": "keyword.control.setting.ggsql",
-          "match": "\\b(?i:SETTING)\\b"
-        },
-        {
-          "name": "keyword.control.fatarrow.ggsql",
-          "match": "(?<!\\S)=>(?!\\S)"
-        },
-        {
-          "name": "support.type.geom.ggsql",
+          "name": "support.type.coord.ggsql",
           "match": "\\b(cartesian|polar|flip|fixed|trans|map|quickmap)\\b"
         },
         {
-          "name": "variable.parameter.coord-property.ggsql",
+          "name": "support.type.property.ggsql",
           "match": "\\b(xlim|ylim|ratio|theta|clip)\\b"
-        }
+        },
+        { "include": "#common-clause-patterns" }
       ]
     },
     "label-clause": {
+      "begin": "(?i)\\b(LABEL)\\b",
+      "beginCaptures": {
+        "1": { "name": "keyword.other.ggsql" }
+      },
+      "end": "(?i)(?=\\b(DRAW|SCALE|COORD|FACET|LABEL|GUIDE|THEME|VISUALISE|VISUALIZE|SELECT|WHERE|WITH)\\b)",
       "patterns": [
         {
-          "name": "keyword.control.label.ggsql",
-          "match": "\\b(?i:LABEL)\\b"
+          "name": "support.type.property.ggsql",
+          "match": "\\b(title|subtitle|x|y|caption|tag|color|colour|fill|size|shape|linetype)\\b"
         },
-        {
-          "name": "variable.parameter.label-type.ggsql",
-          "match": "\\b(title|subtitle|x|y|caption|tag)\\b"
-        }
+        { "include": "#common-clause-patterns" }
       ]
     },
     "guide-clause": {
+      "begin": "(?i)\\b(GUIDE)\\b",
+      "beginCaptures": {
+        "1": { "name": "keyword.other.ggsql" }
+      },
+      "end": "(?i)(?=\\b(DRAW|SCALE|COORD|FACET|LABEL|GUIDE|THEME|VISUALISE|VISUALIZE|SELECT|WHERE|WITH)\\b)",
       "patterns": [
-        {
-          "name": "keyword.control.guide.ggsql",
-          "match": "\\b(?i:GUIDE)\\b"
-        },
-        {
-          "name": "keyword.control.setting.ggsql",
-          "match": "\\b(?i:SETTING)\\b"
-        },
-        {
-          "name": "keyword.control.fatarrow.ggsql",
-          "match": "(?<!\\S)=>(?!\\S)"
-        },
         {
           "name": "constant.language.guide-type.ggsql",
           "match": "\\b(legend|colorbar|axis|none)\\b"
         },
         {
-          "name": "variable.parameter.guide-property.ggsql",
+          "name": "support.type.property.ggsql",
           "match": "\\b(position|direction|nrow|ncol|title|title_position|label_position|text_angle|text_size|reverse|order)\\b"
-        }
+        },
+        { "include": "#common-clause-patterns" }
       ]
     },
     "theme-clause": {
+      "begin": "(?i)\\b(THEME)\\b",
+      "beginCaptures": {
+        "1": { "name": "keyword.other.ggsql" }
+      },
+      "end": "(?i)(?=\\b(DRAW|SCALE|COORD|FACET|LABEL|GUIDE|THEME|VISUALISE|VISUALIZE|SELECT|WHERE|WITH)\\b)",
       "patterns": [
         {
-          "name": "keyword.control.theme.ggsql",
-          "match": "\\b(?i:THEME)\\b"
-        },
-        {
-          "name": "keyword.control.setting.ggsql",
-          "match": "\\b(?i:SETTING)\\b"
-        },
-        {
-          "name": "keyword.control.fatarrow.ggsql",
-          "match": "(?<!\\S)=>(?!\\S)"
-        },
-        {
-          "name": "support.type.geom.ggsql",
+          "name": "support.type.theme.ggsql",
           "match": "\\b(minimal|classic|gray|grey|bw|dark|light|void)\\b"
         },
         {
-          "name": "variable.parameter.theme-property.ggsql",
+          "name": "support.type.property.ggsql",
           "match": "\\b(background|panel_background|panel_grid|panel_grid_major|panel_grid_minor|text_size|text_family|title_size|axis_text_size|axis_line|axis_line_width|panel_border|plot_margin|panel_spacing|legend_background|legend_position|legend_direction)\\b"
-        }
+        },
+        { "include": "#common-clause-patterns" }
       ]
     }
   }


### PR DESCRIPTION
Updates syntax definition files for both Quarto and VSCode/Positron.

The definition files are largely LLM output based on its internal knowledge of SQL and the contents of `grammar.js`. There otherwise seems to be no easy automatic way to convert `grammar.js` into syntax definitions, unfortunately.

As such, reviewing this PR is largely an exercise of taking a look at code in Positron with the extension active, and looking at the rendered Quarto output.

Some screenshots:

<img width="757" height="548" alt="Screenshot 2026-01-23 at 15 47 55" src="https://github.com/user-attachments/assets/e1ebbd71-36cc-4d69-8aef-ea2d55bd7e55" />
<img width="747" height="541" alt="Screenshot 2026-01-23 at 16 57 00" src="https://github.com/user-attachments/assets/fd3c8879-ed07-4618-8fbc-b77787dfc56e" />
<img width="825" height="532" alt="Screenshot 2026-01-23 at 16 56 26" src="https://github.com/user-attachments/assets/417b6555-f072-40f1-995f-6acb043469ec" />


Fixes #79.