### PR TITLE
Skip including data that is not used by layers

### DIFF
--- a/src/writer/vegalite.rs
+++ b/src/writer/vegalite.rs
@@ -1054,6 +1054,10 @@ impl Writer for VegaLiteWriter {
         // Build datasets - convert all DataFrames to Vega-Lite format
         let mut datasets = Map::new();
         for (key, df) in data {
+            if !layer_data_keys.contains(key) {
+                // If we don't need to include (global) data in output, skip it to save space
+                continue;
+            }
             let values = self.dataframe_to_values(df)?;
             datasets.insert(key.clone(), json!(values));
         }


### PR DESCRIPTION
This PR aims to fix #87.

In particular, when you're using a single stat-layer, you only have need of the layer data, not the global data. This PR skips including data if no layer has the key for this data.
