### PR TITLE
feat(rest): add SQL endpoint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,6 +66,7 @@ uuid = { version = "1.0", features = ["v4"] }
 # Web server
 axum = "0.7"
 tokio = { version = "1.35", features = ["full"] }
+tower = "0.5"
 tower-http = { version = "0.5", features = ["cors", "trace"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/src/Cargo.toml
+++ b/src/Cargo.toml
@@ -68,6 +68,7 @@ pyo3 = { workspace = true, optional = true }
 
 [dev-dependencies]
 proptest.workspace = true
+tower = { workspace = true }
 
 [features]
 default = ["duckdb", "sqlite", "vegalite"]


### PR DESCRIPTION
- Add `/api/v1/sql` endpoint for executing plain SQL queries (no VISUALISE clause)
- Returns JSON with rows, columns, row count, and truncation status
- Configurable row limit via `--sql-max-rows` CLI flag (default: 10,000)
- Results are truncated (not errored) when limit is exceeded

## API

**Request:**
```json
{"query": "SELECT * FROM my_table WHERE x > 10"}
```

**Response:**
```json
{
  "status": "success",
  "data": {
    "rows": [{"id": 1, "name": "Alice"}, ...],
    "columns": ["id", "name"],
    "rowCount": 150,
    "truncated": false
  }
}
```


🤖 Generated with [Claude Code](https://claude.ai/code)