### PR TITLE
fix: chunk large DataFrames in register to avoid duckdb-rs panic

### DIFF
--- a/src/reader/duckdb.rs
+++ b/src/reader/duckdb.rs
@@ -558,10 +558,7 @@ impl Reader for DuckDBReader {
                 let chunk_size = std::cmp::min(MAX_ARROW_BATCH_ROWS, total_rows - offset);
                 let chunk = df.slice(offset as i64, chunk_size);
                 let params = dataframe_to_arrow_params(chunk)?;
-                let insert_sql = format!(
-                    "INSERT INTO \"{}\" SELECT * FROM arrow(?, ?)",
-                    name
-                );
+                let insert_sql = format!("INSERT INTO \"{}\" SELECT * FROM arrow(?, ?)", name);
                 self.conn.execute(&insert_sql, params).map_err(|e| {
                     GgsqlError::ReaderError(format!(
                         "Failed to insert chunk into table '{}': {}",
@@ -859,9 +856,18 @@ mod tests {
         let result = reader
             .execute_sql("SELECT id, name FROM large_table ORDER BY id LIMIT 1")
             .unwrap();
-        assert_eq!(result.column("id").unwrap().i32().unwrap().get(0).unwrap(), 0);
         assert_eq!(
-            result.column("name").unwrap().str().unwrap().get(0).unwrap(),
+            result.column("id").unwrap().i32().unwrap().get(0).unwrap(),
+            0
+        );
+        assert_eq!(
+            result
+                .column("name")
+                .unwrap()
+                .str()
+                .unwrap()
+                .get(0)
+                .unwrap(),
             "item_0"
         );
 
@@ -873,7 +879,13 @@ mod tests {
             (n - 1) as i32
         );
         assert_eq!(
-            result.column("name").unwrap().str().unwrap().get(0).unwrap(),
+            result
+                .column("name")
+                .unwrap()
+                .str()
+                .unwrap()
+                .get(0)
+                .unwrap(),
             format!("item_{}", n - 1)
         );
     }


### PR DESCRIPTION
## Summary

`DuckDBReader::register` panics on any DataFrame with more than 2048 rows. This affects all callers — including the Python bindings (`PyDuckDBReader.register`) — making it impossible to register moderately-sized datasets.

### Root cause

`dataframe_to_arrow_params` concatenates all Arrow IPC batches into a single `RecordBatch`, then passes it to `duckdb-rs`'s `arrow()` table function. That function's `ArrowVTab::func` writes the entire RecordBatch into a single DuckDB `DataChunk` in one call — but `DataChunk` vectors have a fixed capacity of `STANDARD_VECTOR_SIZE` (2048). When the RecordBatch has more rows than that, `FlatVector::copy` hits `assert!(data.len() <= self.capacity())` and the process aborts.

### Fix

Chunk DataFrames larger than 2048 rows before passing them to `dataframe_to_arrow_params`. The first chunk creates the table (`CREATE TEMP TABLE ... AS SELECT * FROM arrow(?, ?)`), and subsequent chunks insert into it (`INSERT INTO ... SELECT * FROM arrow(?, ?)`). Small DataFrames (≤2048 rows) take the existing single-batch path with no overhead.

This is a workaround for a bug in `duckdb-rs`'s `ArrowVTab` implementation rather than a fundamental limitation of DuckDB itself.

## Test plan

- [x] Added `test_register_large_dataframe` (3000 rows with int, float, and string columns — verifies row count and data integrity at chunk boundaries)
- [x] All existing register tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)