### PR TITLE
Fix literal mappings

### DIFF
--- a/src/writer/vegalite.rs
+++ b/src/writer/vegalite.rs
@@ -1303,9 +1303,11 @@ impl VegaLiteWriter {
                     } else {
                         " (global data)".to_string()
                     };
+                    // Use user-friendly column name (extract aesthetic name from internal names)
+                    let display_col = naming::extract_aesthetic_name(col).unwrap_or(col.as_str());
                     return Err(GgsqlError::ValidationError(format!(
                         "Column '{}' referenced in aesthetic '{}' (layer {}{}) does not exist.\nAvailable columns: {}",
-                        col,
+                        display_col,
                         aesthetic,
                         layer_idx + 1,
                         source_desc,


### PR DESCRIPTION
Fix #129

This PR fixes two things surfaced by #129. First it fixes the actual error. The issue was that some stats may drop everything not created by themselves and that aren't part of the grouping. The fix is straightforward as we can just add literal mapping columns to the array of grouping columns.

The second issue was the error message which showed the raw internal column names instead of the formatted ones