### PR TITLE
fix: use utcFormat for temporal axis label comparisons

### DIFF
--- a/src/writer/vegalite/encoding.rs
+++ b/src/writer/vegalite/encoding.rs
@@ -993,7 +993,10 @@ mod tests {
     fn test_build_label_expr_fallback() {
         let mappings = HashMap::new();
         let expr = build_label_expr(&mappings, Some("%Y-%m-%d"), None);
-        assert_eq!(expr, "datum.label", "empty mappings should fall back to datum.label");
+        assert_eq!(
+            expr, "datum.label",
+            "empty mappings should fall back to datum.label"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Problem

Date axis labels show nonsensical time-of-day values like "06 PM" / "07 PM" instead of formatted dates when using `RENAMING` on temporal scales (e.g., `SCALE x VIA date RENAMING * => '{:time %b %Y}'`).

The x-axis should show month/year labels like "Jan 2024", "Feb 2024", etc. — instead it shows "06 PM" / "07 PM" alternating (the alternation is caused by DST shifts).

## Root Cause

The Vega-Lite `labelExpr` generated for temporal scales used `timeFormat(datum.value, '%Y-%m-%d')` to compare axis tick values against ISO date keys from the `RENAMING` clause. The problem is that `timeFormat` formats timestamps in the **browser's local timezone**, while ggsql writes all temporal data as **UTC** ISO strings.

In any non-UTC timezone, every comparison silently fails:

| Step | UTC (correct) | US Central (actual) |
|------|--------------|-------------------|
| Data value | `"2024-01-01"` → midnight UTC | same |
| `timeFormat(datum.value, '%Y-%m-%d')` | `"2024-01-01"` | `"2023-12-31"` (6 PM local = previous day) |
| Comparison vs key `"2024-01-01"` | ✅ match | ❌ no match |

When all comparisons fail, the `labelExpr` falls through to `datum.label` (Vega-Lite's default temporal formatter). Since the tick values are midnight UTC — which translates to ~6 PM local time — Vega-Lite auto-formats them as time-of-day labels. The "06 PM" / "07 PM" alternation comes from DST: winter months are UTC-6, summer months are UTC-5.

## Fix

One-line change: `timeFormat` → `utcFormat` in `build_label_expr()`. The `utcFormat` function formats in UTC, matching the ISO date keys that ggsql generates.

## Test Plan

- Added 4 unit tests for `build_label_expr` covering temporal (utcFormat), non-temporal (datum.label), empty mappings (fallback), and null suppression
- All 944 existing tests continue to pass