### PR TITLE
ci: forward GGSQL_SKIP_GENERATE into manylinux Docker container

### DIFF
--- a/.github/workflows/python-release.yml
+++ b/.github/workflows/python-release.yml
@@ -67,6 +67,9 @@ jobs:
           # aarch64 assembly (missing __ARM_ARCH). 2_28 (AlmaLinux 8, gcc 8+)
           # provides a new enough toolchain.
           manylinux: 2_28
+          # Forward GGSQL_SKIP_GENERATE into the Docker container so the
+          # build script uses the pre-generated parser files.
+          docker-options: -e GGSQL_SKIP_GENERATE=1
 
       - uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
Follow up to #112

Updates the Python release workflow to pass `GGSQL_SKIP_GENERATE=1` into the manylinux Docker container. This way, the Linux aarch64 build will properly use pre-generated parser files instead of attempting to regenerate them inside the container.