### PR TITLE
feat(python): typed exceptions, Reader protocol, and bridge fix

### DIFF
--- a/ggsql-python/python/ggsql/__init__.py
+++ b/ggsql-python/python/ggsql/__init__.py
@@ -15,6 +15,10 @@ from ggsql._ggsql import (
     Spec,
     validate,
     execute,
+    ParseError,
+    ValidationError,
+    ReaderError,
+    WriterError,
 )
 
 __all__ = [
@@ -28,6 +32,11 @@ __all__ = [
     "validate",
     "execute",
     "render_altair",
+    # Exceptions
+    "ParseError",
+    "ValidationError",
+    "ReaderError",
+    "WriterError",
 ]
 __version__ = "0.1.4"
 

--- a/ggsql-python/python/ggsql/__init__.py
+++ b/ggsql-python/python/ggsql/__init__.py
@@ -9,7 +9,7 @@ from narwhals.typing import IntoFrame
 
 from ggsql._ggsql import (
     DuckDBReader,
-    VegaLiteWriter,
+    VegaLiteWriter as _RustVegaLiteWriter,
     Validated,
     Spec,
     validate,
@@ -39,6 +39,64 @@ AltairChart = Union[
     altair.VConcatChart,
     altair.RepeatChart,
 ]
+
+
+def _json_to_altair_chart(vegalite_json: str, **kwargs: Any) -> AltairChart:
+    """Convert a Vega-Lite JSON string to the appropriate Altair chart type."""
+    spec = json.loads(vegalite_json)
+
+    if "layer" in spec:
+        return altair.LayerChart.from_json(vegalite_json, **kwargs)
+    elif "facet" in spec or "spec" in spec:
+        return altair.FacetChart.from_json(vegalite_json, **kwargs)
+    elif "concat" in spec:
+        return altair.ConcatChart.from_json(vegalite_json, **kwargs)
+    elif "hconcat" in spec:
+        return altair.HConcatChart.from_json(vegalite_json, **kwargs)
+    elif "vconcat" in spec:
+        return altair.VConcatChart.from_json(vegalite_json, **kwargs)
+    elif "repeat" in spec:
+        return altair.RepeatChart.from_json(vegalite_json, **kwargs)
+    else:
+        return altair.Chart.from_json(vegalite_json, **kwargs)
+
+
+class VegaLiteWriter:
+    """Vega-Lite v6 JSON output writer.
+
+    Methods
+    -------
+    render(spec)
+        Render a Spec to a Vega-Lite JSON string.
+    render_chart(spec, **kwargs)
+        Render a Spec to an Altair chart object.
+    """
+
+    def __init__(self) -> None:
+        self._inner = _RustVegaLiteWriter()
+
+    def render(self, spec: Spec) -> str:
+        """Render a Spec to a Vega-Lite JSON string."""
+        return self._inner.render(spec)
+
+    def render_chart(self, spec: Spec, **kwargs: Any) -> AltairChart:
+        """Render a Spec to an Altair chart object.
+
+        Parameters
+        ----------
+        spec
+            The resolved visualization specification from ``reader.execute()``.
+        **kwargs
+            Additional keyword arguments passed to ``altair.Chart.from_json()``.
+            Common options include ``validate=False`` to skip schema validation.
+
+        Returns
+        -------
+        AltairChart
+            An Altair chart object (Chart, LayerChart, FacetChart, etc.).
+        """
+        vegalite_json = self.render(spec)
+        return _json_to_altair_chart(vegalite_json, **kwargs)
 
 
 def render_altair(
@@ -86,21 +144,4 @@ def render_altair(
     writer = VegaLiteWriter()
     vegalite_json = writer.render(spec)
 
-    # Parse to determine the correct Altair class
-    spec = json.loads(vegalite_json)
-
-    # Determine the correct Altair class based on spec structure
-    if "layer" in spec:
-        return altair.LayerChart.from_json(vegalite_json, **kwargs)
-    elif "facet" in spec or "spec" in spec:
-        return altair.FacetChart.from_json(vegalite_json, **kwargs)
-    elif "concat" in spec:
-        return altair.ConcatChart.from_json(vegalite_json, **kwargs)
-    elif "hconcat" in spec:
-        return altair.HConcatChart.from_json(vegalite_json, **kwargs)
-    elif "vconcat" in spec:
-        return altair.VConcatChart.from_json(vegalite_json, **kwargs)
-    elif "repeat" in spec:
-        return altair.RepeatChart.from_json(vegalite_json, **kwargs)
-    else:
-        return altair.Chart.from_json(vegalite_json, **kwargs)
+    return _json_to_altair_chart(vegalite_json, **kwargs)

--- a/ggsql-python/python/ggsql/__init__.py
+++ b/ggsql-python/python/ggsql/__init__.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
 import json
-from typing import Any, Union
+from typing import Any, Protocol, Union, runtime_checkable
 
 import altair
 import narwhals as nw
 from narwhals.typing import IntoFrame
+import polars as pl
 
 from ggsql._ggsql import (
     DuckDBReader,
@@ -22,12 +23,13 @@ __all__ = [
     "VegaLiteWriter",
     "Validated",
     "Spec",
+    "Reader",
     # Functions
     "validate",
     "execute",
     "render_altair",
 ]
-__version__ = "0.1.0"
+__version__ = "0.1.4"
 
 # Type alias for any Altair chart type
 AltairChart = Union[
@@ -39,6 +41,29 @@ AltairChart = Union[
     altair.VConcatChart,
     altair.RepeatChart,
 ]
+
+
+@runtime_checkable
+class Reader(Protocol):
+    """Protocol for ggsql database readers.
+
+    Any object implementing these methods can be used as a reader with
+    ``ggsql.execute()``. Native readers like ``DuckDBReader`` satisfy
+    this protocol automatically.
+
+    Required methods
+    ----------------
+    execute_sql(sql: str) -> polars.DataFrame
+        Execute a SQL query and return results as a polars DataFrame.
+    register(name: str, df: polars.DataFrame, replace: bool = False) -> None
+        Register a DataFrame as a named table for SQL queries.
+    """
+
+    def execute_sql(self, sql: str) -> pl.DataFrame: ...
+
+    def register(
+        self, name: str, df: pl.DataFrame, replace: bool = False
+    ) -> None: ...
 
 
 def _json_to_altair_chart(vegalite_json: str, **kwargs: Any) -> AltairChart:

--- a/ggsql-python/src/lib.rs
+++ b/ggsql-python/src/lib.rs
@@ -3,6 +3,8 @@
 #![allow(clippy::useless_conversion)]
 
 use pyo3::prelude::*;
+use pyo3::create_exception;
+use pyo3::exceptions::PyValueError;
 use pyo3::types::{PyBytes, PyDict, PyList};
 use std::io::Cursor;
 
@@ -11,6 +13,28 @@ use ggsql::reader::{DuckDBReader as RustDuckDBReader, Reader};
 use ggsql::validate::{validate as rust_validate, ValidationWarning};
 use ggsql::writer::{VegaLiteWriter as RustVegaLiteWriter, Writer as RustWriter};
 use ggsql::GgsqlError;
+
+// ============================================================================
+// Custom Exception Classes
+// ============================================================================
+
+// All subclass ValueError for backwards compatibility
+create_exception!(ggsql, ParseError, PyValueError, "Raised on query syntax errors.");
+create_exception!(ggsql, ValidationError, PyValueError, "Raised on semantic validation errors.");
+create_exception!(ggsql, ReaderError, PyValueError, "Raised on data source errors.");
+create_exception!(ggsql, WriterError, PyValueError, "Raised on output generation errors.");
+
+/// Convert a GgsqlError to the appropriate typed Python exception.
+fn ggsql_err_to_py(e: GgsqlError) -> PyErr {
+    let msg = e.to_string();
+    match e {
+        GgsqlError::ParseError(_) => PyErr::new::<ParseError, _>(msg),
+        GgsqlError::ValidationError(_) => PyErr::new::<ValidationError, _>(msg),
+        GgsqlError::ReaderError(_) => PyErr::new::<ReaderError, _>(msg),
+        GgsqlError::WriterError(_) => PyErr::new::<WriterError, _>(msg),
+        GgsqlError::InternalError(_) => PyErr::new::<PyValueError, _>(msg),
+    }
+}
 
 use polars::prelude::{DataFrame, IpcReader, IpcWriter, SerReader, SerWriter};
 
@@ -175,7 +199,7 @@ macro_rules! try_native_readers {
             if let Ok(native) = $reader.downcast::<$native_type>() {
                 return native.borrow().inner.execute($query)
                     .map(|s| PySpec { inner: s })
-                    .map_err(|e| PyErr::new::<pyo3::exceptions::PyValueError, _>(e.to_string()));
+                    .map_err(ggsql_err_to_py);
             }
         )*
     }};
@@ -225,7 +249,7 @@ impl PyDuckDBReader {
     #[new]
     fn new(connection: &str) -> PyResult<Self> {
         let inner = RustDuckDBReader::from_connection_string(connection)
-            .map_err(|e| PyErr::new::<pyo3::exceptions::PyValueError, _>(e.to_string()))?;
+            .map_err(ggsql_err_to_py)?;
         Ok(Self { inner })
     }
 
@@ -255,7 +279,7 @@ impl PyDuckDBReader {
         let rust_df = py_to_polars(py, df)?;
         self.inner
             .register(name, rust_df, replace)
-            .map_err(|e| PyErr::new::<pyo3::exceptions::PyValueError, _>(e.to_string()))
+            .map_err(ggsql_err_to_py)
     }
 
     /// Unregister a previously registered table.
@@ -272,7 +296,7 @@ impl PyDuckDBReader {
     fn unregister(&self, name: &str) -> PyResult<()> {
         self.inner
             .unregister(name)
-            .map_err(|e| PyErr::new::<pyo3::exceptions::PyValueError, _>(e.to_string()))
+            .map_err(ggsql_err_to_py)
     }
 
     /// Execute a SQL query and return the result as a DataFrame.
@@ -295,7 +319,7 @@ impl PyDuckDBReader {
         let df = self
             .inner
             .execute_sql(sql)
-            .map_err(|e| PyErr::new::<pyo3::exceptions::PyValueError, _>(e.to_string()))?;
+            .map_err(ggsql_err_to_py)?;
         polars_to_py(py, &df)
     }
 
@@ -330,7 +354,7 @@ impl PyDuckDBReader {
         self.inner
             .execute(query)
             .map(|s| PySpec { inner: s })
-            .map_err(|e| PyErr::new::<pyo3::exceptions::PyValueError, _>(e.to_string()))
+            .map_err(ggsql_err_to_py)
     }
 }
 
@@ -393,7 +417,7 @@ impl PyVegaLiteWriter {
     fn render(&self, spec: &PySpec) -> PyResult<String> {
         self.inner
             .render(&spec.inner)
-            .map_err(|e| PyErr::new::<pyo3::exceptions::PyValueError, _>(e.to_string()))
+            .map_err(ggsql_err_to_py)
     }
 }
 
@@ -658,7 +682,7 @@ impl PySpec {
 #[pyfunction]
 fn validate(query: &str) -> PyResult<PyValidated> {
     let v = rust_validate(query)
-        .map_err(|e| PyErr::new::<pyo3::exceptions::PyValueError, _>(e.to_string()))?;
+        .map_err(ggsql_err_to_py)?;
 
     Ok(PyValidated {
         sql: v.sql().to_string(),
@@ -739,7 +763,7 @@ fn execute(query: &str, reader: &Bound<'_, PyAny>) -> PyResult<PySpec> {
     bridge
         .execute(query)
         .map(|s| PySpec { inner: s })
-        .map_err(|e| PyErr::new::<pyo3::exceptions::PyValueError, _>(e.to_string()))
+        .map_err(ggsql_err_to_py)
 }
 
 // ============================================================================
@@ -748,6 +772,12 @@ fn execute(query: &str, reader: &Bound<'_, PyAny>) -> PyResult<PySpec> {
 
 #[pymodule]
 fn _ggsql(m: &Bound<'_, PyModule>) -> PyResult<()> {
+    // Exceptions
+    m.add("ParseError", m.py().get_type::<ParseError>())?;
+    m.add("ValidationError", m.py().get_type::<ValidationError>())?;
+    m.add("ReaderError", m.py().get_type::<ReaderError>())?;
+    m.add("WriterError", m.py().get_type::<WriterError>())?;
+
     // Classes
     m.add_class::<PyDuckDBReader>()?;
     m.add_class::<PyVegaLiteWriter>()?;

--- a/ggsql-python/src/lib.rs
+++ b/ggsql-python/src/lib.rs
@@ -166,9 +166,13 @@ impl Reader for PyReaderBridge {
         Python::attach(|py| {
             let py_df =
                 polars_to_py(py, &df).map_err(|e| GgsqlError::ReaderError(e.to_string()))?;
+            let kwargs = PyDict::new(py);
+            kwargs
+                .set_item("replace", replace)
+                .map_err(|e| GgsqlError::ReaderError(e.to_string()))?;
             self.obj
                 .bind(py)
-                .call_method1("register", (name, py_df, replace))
+                .call_method("register", (name, py_df), Some(&kwargs))
                 .map_err(|e| GgsqlError::ReaderError(format!("Reader.register() failed: {}", e)))?;
             Ok(())
         })

--- a/ggsql-python/src/lib.rs
+++ b/ggsql-python/src/lib.rs
@@ -2,9 +2,9 @@
 // See: https://github.com/PyO3/pyo3/issues/4327
 #![allow(clippy::useless_conversion)]
 
-use pyo3::prelude::*;
 use pyo3::create_exception;
 use pyo3::exceptions::PyValueError;
+use pyo3::prelude::*;
 use pyo3::types::{PyBytes, PyDict, PyList};
 use std::io::Cursor;
 
@@ -19,10 +19,30 @@ use ggsql::GgsqlError;
 // ============================================================================
 
 // All subclass ValueError for backwards compatibility
-create_exception!(ggsql, ParseError, PyValueError, "Raised on query syntax errors.");
-create_exception!(ggsql, ValidationError, PyValueError, "Raised on semantic validation errors.");
-create_exception!(ggsql, ReaderError, PyValueError, "Raised on data source errors.");
-create_exception!(ggsql, WriterError, PyValueError, "Raised on output generation errors.");
+create_exception!(
+    ggsql,
+    ParseError,
+    PyValueError,
+    "Raised on query syntax errors."
+);
+create_exception!(
+    ggsql,
+    ValidationError,
+    PyValueError,
+    "Raised on semantic validation errors."
+);
+create_exception!(
+    ggsql,
+    ReaderError,
+    PyValueError,
+    "Raised on data source errors."
+);
+create_exception!(
+    ggsql,
+    WriterError,
+    PyValueError,
+    "Raised on output generation errors."
+);
 
 /// Convert a GgsqlError to the appropriate typed Python exception.
 fn ggsql_err_to_py(e: GgsqlError) -> PyErr {
@@ -252,8 +272,8 @@ impl PyDuckDBReader {
     ///     If the connection string is invalid or the database cannot be opened.
     #[new]
     fn new(connection: &str) -> PyResult<Self> {
-        let inner = RustDuckDBReader::from_connection_string(connection)
-            .map_err(ggsql_err_to_py)?;
+        let inner =
+            RustDuckDBReader::from_connection_string(connection).map_err(ggsql_err_to_py)?;
         Ok(Self { inner })
     }
 
@@ -298,9 +318,7 @@ impl PyDuckDBReader {
     /// ValueError
     ///     If the table wasn't registered via this reader or unregistration fails.
     fn unregister(&self, name: &str) -> PyResult<()> {
-        self.inner
-            .unregister(name)
-            .map_err(ggsql_err_to_py)
+        self.inner.unregister(name).map_err(ggsql_err_to_py)
     }
 
     /// Execute a SQL query and return the result as a DataFrame.
@@ -320,10 +338,7 @@ impl PyDuckDBReader {
     /// ValueError
     ///     If the SQL is invalid or execution fails.
     fn execute_sql(&self, py: Python<'_>, sql: &str) -> PyResult<Py<PyAny>> {
-        let df = self
-            .inner
-            .execute_sql(sql)
-            .map_err(ggsql_err_to_py)?;
+        let df = self.inner.execute_sql(sql).map_err(ggsql_err_to_py)?;
         polars_to_py(py, &df)
     }
 
@@ -419,9 +434,7 @@ impl PyVegaLiteWriter {
     /// >>> writer = VegaLiteWriter()
     /// >>> json_output = writer.render(spec)
     fn render(&self, spec: &PySpec) -> PyResult<String> {
-        self.inner
-            .render(&spec.inner)
-            .map_err(ggsql_err_to_py)
+        self.inner.render(&spec.inner).map_err(ggsql_err_to_py)
     }
 }
 
@@ -685,8 +698,7 @@ impl PySpec {
 ///     If validation fails unexpectedly (not for syntax errors, which are captured).
 #[pyfunction]
 fn validate(query: &str) -> PyResult<PyValidated> {
-    let v = rust_validate(query)
-        .map_err(ggsql_err_to_py)?;
+    let v = rust_validate(query).map_err(ggsql_err_to_py)?;
 
     Ok(PyValidated {
         sql: v.sql().to_string(),

--- a/ggsql-python/tests/test_ggsql.py
+++ b/ggsql-python/tests/test_ggsql.py
@@ -532,6 +532,53 @@ class TestCustomReader:
         assert "point" in json_output
 
 
+class TestExceptions:
+    """Tests for typed exception classes."""
+
+    def test_parse_error_on_invalid_syntax(self):
+        """Invalid syntax raises ParseError when executing."""
+        with pytest.raises(ggsql.ParseError):
+            reader = ggsql.DuckDBReader("duckdb://memory")
+            reader.execute("SELECT 1 AS x VISUALISE DRAW not_a_geom")
+
+    def test_parse_error_is_value_error(self):
+        """ParseError is a subclass of ValueError for backwards compat."""
+        assert issubclass(ggsql.ParseError, ValueError)
+
+    def test_validation_error_on_missing_aesthetic(self):
+        """Missing required aesthetic raises ValidationError."""
+        with pytest.raises(ggsql.ValidationError):
+            reader = ggsql.DuckDBReader("duckdb://memory")
+            reader.execute("SELECT 1 AS x VISUALISE DRAW point MAPPING x AS x")
+
+    def test_validation_error_is_value_error(self):
+        """ValidationError is a subclass of ValueError for backwards compat."""
+        assert issubclass(ggsql.ValidationError, ValueError)
+
+    def test_reader_error_on_bad_sql(self):
+        """Bad SQL raises ReaderError."""
+        with pytest.raises(ggsql.ReaderError):
+            reader = ggsql.DuckDBReader("duckdb://memory")
+            reader.execute(
+                "SELECT * FROM nonexistent_table VISUALISE DRAW point MAPPING x AS x, y AS y"
+            )
+
+    def test_reader_error_is_value_error(self):
+        """ReaderError is a subclass of ValueError for backwards compat."""
+        assert issubclass(ggsql.ReaderError, ValueError)
+
+    def test_writer_error_is_value_error(self):
+        """WriterError is a subclass of ValueError for backwards compat."""
+        assert issubclass(ggsql.WriterError, ValueError)
+
+    def test_all_exceptions_exported(self):
+        """All exception classes are accessible from ggsql module."""
+        assert hasattr(ggsql, "ParseError")
+        assert hasattr(ggsql, "ValidationError")
+        assert hasattr(ggsql, "ReaderError")
+        assert hasattr(ggsql, "WriterError")
+
+
 class TestReaderProtocol:
     """Tests for Reader protocol."""
 

--- a/ggsql-python/tests/test_ggsql.py
+++ b/ggsql-python/tests/test_ggsql.py
@@ -530,3 +530,42 @@ class TestCustomReader:
         writer = ggsql.VegaLiteWriter()
         json_output = writer.render(spec)
         assert "point" in json_output
+
+
+class TestVegaLiteWriterRenderChart:
+    """Tests for VegaLiteWriter.render_chart() method."""
+
+    def test_render_chart_returns_altair_chart(self):
+        """render_chart() returns an Altair chart object."""
+        reader = ggsql.DuckDBReader("duckdb://memory")
+        spec = reader.execute("SELECT 1 AS x, 2 AS y VISUALISE x, y DRAW point")
+        writer = ggsql.VegaLiteWriter()
+        chart = writer.render_chart(spec)
+        assert isinstance(chart, altair.TopLevelMixin)
+
+    def test_render_chart_layer(self):
+        """render_chart() returns LayerChart for layered specs."""
+        reader = ggsql.DuckDBReader("duckdb://memory")
+        spec = reader.execute("SELECT 1 AS x, 2 AS y VISUALISE x, y DRAW point")
+        writer = ggsql.VegaLiteWriter()
+        chart = writer.render_chart(spec)
+        assert isinstance(chart, altair.LayerChart)
+
+    def test_render_chart_facet(self):
+        """render_chart() returns FacetChart for faceted specs."""
+        reader = ggsql.DuckDBReader("duckdb://memory")
+        df = pl.DataFrame(
+            {
+                "x": [1, 2, 3, 4, 5, 6],
+                "y": [10, 20, 30, 40, 50, 60],
+                "group": ["A", "A", "A", "B", "B", "B"],
+            }
+        )
+        reader.register("data", df)
+        spec = reader.execute(
+            "SELECT * FROM data VISUALISE x, y FACET group DRAW point"
+        )
+        writer = ggsql.VegaLiteWriter()
+        chart = writer.render_chart(spec, validate=False)
+        assert isinstance(chart, altair.FacetChart)
+

--- a/ggsql-python/tests/test_ggsql.py
+++ b/ggsql-python/tests/test_ggsql.py
@@ -532,6 +532,45 @@ class TestCustomReader:
         assert "point" in json_output
 
 
+class TestReaderProtocol:
+    """Tests for Reader protocol."""
+
+    def test_duckdb_reader_is_reader(self):
+        """Native DuckDBReader satisfies the Reader protocol."""
+        reader = ggsql.DuckDBReader("duckdb://memory")
+        assert isinstance(reader, ggsql.Reader)
+
+    def test_custom_reader_is_reader(self):
+        """Custom reader with correct methods satisfies the Reader protocol."""
+
+        class MyReader:
+            def execute_sql(self, sql: str) -> pl.DataFrame:
+                return pl.DataFrame({"x": [1]})
+
+            def register(
+                self, name: str, df: pl.DataFrame, replace: bool = False
+            ) -> None:
+                pass
+
+        reader = MyReader()
+        assert isinstance(reader, ggsql.Reader)
+
+    def test_incomplete_reader_is_not_reader(self):
+        """Object missing required methods is not a Reader."""
+
+        class NotAReader:
+            def execute_sql(self, sql: str) -> pl.DataFrame:
+                return pl.DataFrame({"x": [1]})
+            # Missing register()
+
+        obj = NotAReader()
+        assert not isinstance(obj, ggsql.Reader)
+
+    def test_reader_is_exported(self):
+        """Reader is accessible from ggsql module."""
+        assert hasattr(ggsql, "Reader")
+
+
 class TestVegaLiteWriterRenderChart:
     """Tests for VegaLiteWriter.render_chart() method."""
 
@@ -568,4 +607,3 @@ class TestVegaLiteWriterRenderChart:
         writer = ggsql.VegaLiteWriter()
         chart = writer.render_chart(spec, validate=False)
         assert isinstance(chart, altair.FacetChart)
-

--- a/ggsql-python/tests/test_ggsql.py
+++ b/ggsql-python/tests/test_ggsql.py
@@ -402,7 +402,7 @@ class TestCustomReader:
             def execute_sql(self, sql: str) -> pl.DataFrame:
                 return self.conn.execute(sql).pl()
 
-            def register(self, name: str, df: pl.DataFrame, _replace: bool) -> None:
+            def register(self, name: str, df: pl.DataFrame, replace: bool = False) -> None:
                 self.conn.register(name, df)
 
         reader = RegisterReader()
@@ -453,7 +453,7 @@ class TestCustomReader:
             def execute_sql(self, sql: str) -> pl.DataFrame:
                 return self.conn.execute(sql).pl()
 
-            def register(self, name: str, df: pl.DataFrame, _replace: bool) -> None:
+            def register(self, name: str, df: pl.DataFrame, replace: bool = False) -> None:
                 self.conn.register(name, df)
 
         reader = DuckDBBackedReader()
@@ -484,7 +484,7 @@ class TestCustomReader:
                 self.execute_calls.append(sql)
                 return self.conn.execute(sql).pl()
 
-            def register(self, name: str, df: pl.DataFrame, _replace: bool) -> None:
+            def register(self, name: str, df: pl.DataFrame, replace: bool = False) -> None:
                 self.conn.register(name, df)
 
         reader = RecordingReader()


### PR DESCRIPTION
Depends on #177 (merge that first)

## Summary
- Add typed exception classes (`ParseError`, `ValidationError`, `ReaderError`, `WriterError`) subclassing `ValueError` for backwards compatibility
- Add `Reader` protocol class defining the contract for custom readers (`execute_sql`, `register`)
- Fix `PyReaderBridge` to pass `replace` as a keyword argument, so custom readers with `register(name, df, *, replace=False)` signatures work correctly

## Rust changes
- `create_exception!` macros for 4 exception types + `ggsql_err_to_py()` mapper
- All `.map_err(...)` sites updated from generic `PyValueError` to typed exceptions
- `PyReaderBridge.register()` uses `call_method` with kwargs instead of `call_method1`
