### PR TITLE
fix: remove invalid `stack` property from secondary position channels

### DIFF
--- a/src/writer/vegalite/mod.rs
+++ b/src/writer/vegalite/mod.rs
@@ -349,24 +349,16 @@ fn build_layer_encoding(
         );
     }
 
-    // Disable Vega-Lite's automatic stacking - we handle position adjustments ourselves
-    // This prevents Vega-Lite from applying its own stack/dodge logic on top of ours
-    // Set stack: null on both y and y2 channels (pos2 and pos2end in our terminology)
+    // Disable Vega-Lite's automatic stacking - we handle position adjustments ourselves.
+    // This prevents Vega-Lite from applying its own stack/dodge logic on top of ours.
+    // Only set stack: null on primary position channels (y/radius) — Vega-Lite does
+    // not support 'stack' on secondary channels (y2/radius2) and Altair rejects it.
     let y_channel = match coord_kind {
         CoordKind::Cartesian => "y",
         CoordKind::Polar => "radius",
     };
-    let y2_channel = match coord_kind {
-        CoordKind::Cartesian => "y2",
-        CoordKind::Polar => "radius2",
-    };
     if let Some(y_enc) = encoding.get_mut(y_channel) {
         if let Some(obj) = y_enc.as_object_mut() {
-            obj.insert("stack".to_string(), Value::Null);
-        }
-    }
-    if let Some(y2_enc) = encoding.get_mut(y2_channel) {
-        if let Some(obj) = y2_enc.as_object_mut() {
             obj.insert("stack".to_string(), Value::Null);
         }
     }
@@ -2703,8 +2695,15 @@ mod tests {
                         enc.get("axis").is_none(),
                         "{channel} should not have 'axis': {enc}"
                     );
+                    assert!(
+                        enc.get("stack").is_none(),
+                        "{channel} should not have 'stack': {enc}"
+                    );
                 }
             }
         }
+
+        // The spec must also pass Vega-Lite schema validation
+        assert_valid_vegalite(&json_str);
     }
 }


### PR DESCRIPTION
## Problem

`build_layer_encoding` emits `"stack": null` on both primary (`y`/`radius`) and secondary (`y2`/`radius2`) position channels to disable Vega-Lite's automatic stacking. However, the [Vega-Lite v6 schema](https://vega.github.io/schema/vega-lite/v6.json) does not allow `stack` on secondary channels — only primary position channels support it.

This causes errors when consuming the JSON output with Altair (Python):
- With `validate=False`: `TypeError: Only chart objects can be used in LayerChart.`
- With `validate=True`: `ValidationError: Additional properties are not allowed ('stack' was unexpected)`

Any spec that produces a `y2` encoding (bars, areas, segments, ribbons, error bars, etc.) is affected.

## Fix

Remove the `stack: null` insertion on `y2`/`radius2` channels. Only primary position channels (`y`/`radius`) need this property — secondary channels don't support independent stacking and inherit behavior from their primary channel.

## Test changes

Strengthened `test_secondary_channels_have_no_disallowed_properties` to:
- Assert `stack` is absent from `x2`/`y2` encodings (was not previously checked)
- Run `assert_valid_vegalite()` for full Vega-Lite schema validation (was not previously called)