### PR TITLE
Allow for using other readers in ggsql cli

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -29,11 +29,11 @@ pub enum Commands {
         /// The ggsql query to execute
         query: String,
 
-        /// Data source connection string
+        /// Data source connection string (duckdb://, sqlite://, polars://)
         #[arg(long, default_value = "duckdb://memory")]
         reader: String,
 
-        /// Output format
+        /// Output format (vegalite)
         #[arg(long, default_value = "vegalite")]
         writer: String,
 
@@ -51,11 +51,11 @@ pub enum Commands {
         /// Path to .sql file containing ggsql query
         file: PathBuf,
 
-        /// Data source connection string
+        /// Data source connection string (duckdb://, sqlite://, polars://)
         #[arg(long, default_value = "duckdb://memory")]
         reader: String,
 
-        /// Output format
+        /// Output format (vegalite)
         #[arg(long, default_value = "vegalite")]
         writer: String,
 
@@ -83,7 +83,7 @@ pub enum Commands {
         /// The ggsql query to validate
         query: String,
 
-        /// Data source connection string (needed for column validation)
+        /// Data source connection string for column validation (duckdb://, sqlite://, polars://)
         #[arg(long)]
         reader: Option<String>,
     },


### PR DESCRIPTION
With this, one should be able to do e.g.

```
cargo run --features sqlite --bin ggsql -- exec --reader sqlite://:memory: 'VISUALISE species AS x, bill_dep AS y, island AS fill FROM ggsql:penguins  DRAW violin'
```

To test queries with the sqlite reader.