### PR TITLE
Fix warnings/errors in wasm sysroot

### DIFF
--- a/ggsql-wasm/demo/package-lock.json
+++ b/ggsql-wasm/demo/package-lock.json
@@ -24,7 +24,7 @@
     },
     "../pkg": {
       "name": "ggsql-wasm",
-      "version": "0.1.0",
+      "version": "0.1.8",
       "license": "MIT"
     },
     "node_modules/@esbuild/aix-ppc64": {

--- a/tree-sitter-ggsql/bindings/rust/wasm-sysroot/src/stdio.c
+++ b/tree-sitter-ggsql/bindings/rust/wasm-sysroot/src/stdio.c
@@ -275,25 +275,35 @@ int vsnprintf(char *restrict buffer, size_t buffsz, const char *restrict format,
 }
 
 int fclose(FILE *stream) {
+  (void)stream;
   return 0;
 }
 
 FILE* fdopen(int fd, const char *mode) {
+  (void)fd;
+  (void)mode;
   return 0;
 }
 
 int fputc(int c, FILE *stream) {
+  (void)stream;
   return c;
 }
 
 int fputs(const char *restrict str, FILE *restrict stream) {
+  (void)str;
+  (void)stream;
   return 0;
 }
 
 size_t fwrite(const void *restrict buffer, size_t size, size_t nmemb, FILE *restrict stream) {
+  (void)buffer;
+  (void)stream;
   return size * nmemb;
 }
 
 int fprintf(FILE *restrict stream, const char *restrict format, ...) {
+  (void)stream;
+  (void)format;
   return 0;
 }

--- a/tree-sitter-ggsql/bindings/rust/wasm-sysroot/src/stdlib.c
+++ b/tree-sitter-ggsql/bindings/rust/wasm-sysroot/src/stdlib.c
@@ -15,7 +15,7 @@ extern void tree_sitter_debug_message(const char *, size_t);
 #define PAGESIZE 0x10000
 #define MAX_HEAP_SIZE (1024 * 1024 * 1024)
 
-typedef struct {
+typedef struct Region {
   size_t size;
   struct Region *next;
   char data[0];


### PR DESCRIPTION
This should (hopefully) fix the build errors @thomasp85 was seeing when running `./build-wasm.sh` with LLVM 22.