### PR TITLE
Boxplot width always uses bandwidth-expression instead of band

### DIFF
--- a/src/writer/vegalite/layer.rs
+++ b/src/writer/vegalite/layer.rs
@@ -284,8 +284,12 @@ impl GeomRenderer for BarRenderer {
         let is_horizontal = is_transposed(layer);
         let axis = if is_horizontal { "y" } else { "x" };
 
-        // Use expression-based size with the adjusted width
-        let size_value = json!({"expr": format!("bandwidth('{}') * {}", axis, width)});
+        let size_value = match layer_spec["encoding"][axis]["bin"].as_str() {
+            // I don't think binned scales obey 'band', but they don't tolerate the 'expr' option.
+            Some("binned") => json!({"band": width}),
+            // Use expression-based size with the adjusted width
+            _ => json!({"expr": format!("bandwidth('{}') * {}", axis, width)}),
+        };
 
         layer_spec["mark"] = if is_horizontal {
             json!({

--- a/src/writer/vegalite/layer.rs
+++ b/src/writer/vegalite/layer.rs
@@ -270,23 +270,22 @@ impl GeomRenderer for BarRenderer {
         layer: &Layer,
         _context: &RenderContext,
     ) -> Result<()> {
-        let width = match layer.parameters.get("width") {
-            Some(ParameterValue::Number(w)) => *w,
-            _ => 0.9,
+        let width = match layer.adjusted_width {
+            // The adjusted width comes from position adjustments
+            Some(adjusted) => adjusted,
+            _ => match layer.parameters.get("width") {
+                // Fallback to width parameter value if there is no adjustment
+                Some(ParameterValue::Number(n)) => *n,
+                _ => 0.9,
+            },
         };
 
         // For horizontal bars, use "height" for band size; for vertical, use "width"
         let is_horizontal = is_transposed(layer);
+        let axis = if is_horizontal { "y" } else { "x" };
 
-        // For dodged bars, use expression-based size with the adjusted width
-        // For non-dodged bars, use band-relative size
-        let size_value = if let Some(adjusted) = layer.adjusted_width {
-            // Use bandwidth expression for dodged bars
-            let axis = if is_horizontal { "y" } else { "x" };
-            json!({"expr": format!("bandwidth('{}') * {}", axis, adjusted)})
-        } else {
-            json!({"band": width})
-        };
+        // Use expression-based size with the adjusted width
+        let size_value = json!({"expr": format!("bandwidth('{}') * {}", axis, width)});
 
         layer_spec["mark"] = if is_horizontal {
             json!({

--- a/src/writer/vegalite/layer.rs
+++ b/src/writer/vegalite/layer.rs
@@ -1710,25 +1710,19 @@ impl BoxplotRenderer {
 
         let value_var1 = if is_horizontal { "x" } else { "y" };
         let value_var2 = if is_horizontal { "x2" } else { "y2" };
+        let axis = if is_horizontal { "y" } else { "x" };
 
         // Get width parameter
-        let base_width = layer
-            .parameters
-            .get("width")
-            .and_then(|v| match v {
-                ParameterValue::Number(n) => Some(*n),
-                _ => None,
-            })
-            .unwrap_or(0.9);
-
-        // For dodged boxplots, use expression-based width with adjusted_width
-        // For non-dodged boxplots, use band-relative width
-        let axis = if is_horizontal { "y" } else { "x" };
-        let width_value = if let Some(adjusted) = layer.adjusted_width {
-            json!({"expr": format!("bandwidth('{}') * {}", axis, adjusted)})
-        } else {
-            json!({"band": base_width})
+        let width = match layer.adjusted_width {
+            // The adjusted width comes from position adjustments
+            Some(adjusted) => adjusted,
+            _ => match layer.parameters.get("width") {
+                // Fallback to width parameter value if there is no adjustment
+                Some(ParameterValue::Number(n)) => *n,
+                _ => 0.9,
+            },
         };
+        let width_value = json!({"expr": format!("bandwidth('{}') * {}", axis, width)});
 
         // Helper to create filter transform for source selection
         let make_source_filter = |type_suffix: &str| -> Value {


### PR DESCRIPTION
This PR aims to fix #290.
The reason for the original issue is probably that I hadn't known about the expression version when I wrote the boxplot layer.
