### PR TITLE
Use 'transformation' rather than 'transform' for noun usage?

### DIFF
--- a/doc/syntax/scale/type/continuous.qmd
+++ b/doc/syntax/scale/type/continuous.qmd
@@ -12,7 +12,7 @@ The input range for continuous scales are defined by their minimum and maximum v
 Position aesthetics (`x` and `y`) will have their range expanded based on the `expand` setting. 
 If values in the mapped data falls outside of the input domain the values will be changed based on the `oob` setting.
 
-The input range is converted to the type defined by the transform. This means that a time range can both be given as a `%H:%M:%S` string or as a numeric giving the number of nanoseconds since midnight.
+The input range is converted to the type defined by the transformation. This means that a time range can both be given as a `%H:%M:%S` string or as a numeric giving the number of nanoseconds since midnight.
 
 ### Examples
 
@@ -62,23 +62,23 @@ DRAW point
 SCALE color TO ['black', 'red', 'white']
 ```
 
-## Transform
-The transform of the scale both defines how the input data is parsed as well as any mathematical transform applied before it is mapped to the output range. The default transform is deduced from a combination of the mapped data and the aesthetic the scale is applied to. 
+## Transformation
+The transformation of the scale both defines how the input data is parsed as well as any mathematical transformation applied before it is mapped to the output range. The default transformation is deduced from a combination of the mapped data and the aesthetic the scale is applied to. 
 
-* `linear`: The default transform unless stated otherwise. Creates a linear mapping between the input and output range.
+* `linear`: The default transformation unless stated otherwise. Creates a linear mapping between the input and output range.
 * `log`/`log2`/`ln`: Creates a mapping between the logarithm of the input to the output range.
-* `exp10`/`exp2`/`exp`: Inverse of the log transforms
+* `exp10`/`exp2`/`exp`: Inverse of the log transformations
 * `sqrt`: Creates a mapping between the square root of the input to the output range.
-* `square`: Inverse of `sqrt` transform
+* `square`: Inverse of `sqrt` transformation
 * `asinh`: Creates a mapping between the inverse hyperbolic sine of the input to the output range. This approaches the natural logarithm but is well defined for negative values as well, which can make it a good choice for transforming values that exhibit logarithmic growth but span positive and negative values.
-* `pseudo_log`/`pseudo_log2`/`pseudo_ln`: A slightly different transform that exhibit the same characteristics as `asinh` but where it is possible to choose the base of the logarithm it should approach.
+* `pseudo_log`/`pseudo_log2`/`pseudo_ln`: A slightly different transformation that exhibits the same characteristics as `asinh` but where it is possible to choose the base of the logarithm it should approach.
 * `integer`: Like `linear` but will convert input to integer by removing the decimal part.
 * `date`: Default when mapping a DATE column. Like `linear` but will cast input to date if not already (for strings this assumes the date is formatted as YYYY-MM-DD, for numbers it will be the number of days since 1970-01-01).
 * `datetime`: Default when mapping a DATETIME column. Like `linear` but will cast input to datetime if not already (for strings a range of different permutations of the YYYY-MM-DDTHH:MM:SS.fTZ is tried, for number it will be the number of microseconds since 1970-01-01T00:00:00).
 * `time`: Default when mapping a TIME column. Like `linear` but will cast input to time if not already (for strings it assumes the time is formatted as HH:MM:SS.f with both the fractional and second part optional, for number it will be the number of nanoseconds since start of measurement).
 
 ### Breaks
-If not provided explicitly by the user the breaks for the scales will be calculated for you. The transform will be responsible for the algorithm used to find good break values. It will use the breaks setting and the pretty setting and make a best effort at honouring this.
+If not provided explicitly by the user the breaks for the scales will be calculated for you. The transformation will be responsible for the algorithm used to find good break values. It will use the breaks setting and the pretty setting and make a best effort at honouring this.
 
 * `linear`:
   - `pretty => true`: Will use Wilkinsons Extended algorithm to attempt to find nice breaks in the given interval close to the number of breaks requested
@@ -96,16 +96,16 @@ If not provided explicitly by the user the breaks for the scales will be calcula
   - `pretty => false`: Linear spacing in integer space as close to the requested number of breaks
 
 ### The size aesthetic
-The size aesthetic requires special attention. To the user, size is given as radius in points (1/72 inch), but internally the provided values are converted to area, and the scale operates on area transformed values. This means that while you provide the output range in radius, the scaling is proportional to the area, even when using the default linear transform. While this seems somewhat complicated we have chosen this approach to satisfy two opposing needs:
+The size aesthetic requires special attention. To the user, size is given as radius in points (1/72 inch), but internally the provided values are converted to area, and the scale operates on area transformed values. This means that while you provide the output range in radius, the scaling is proportional to the area, even when using the default linear transformation. While this seems somewhat complicated we have chosen this approach to satisfy two opposing needs:
 
 1. Humans are better at understanding a size when provided as radius/diameter
 2. When making comparison between shape sizes we should compare area
 
-If you wish to scale by the radius (not advised) you should do so using the `square` transform (`SCALE size VIA square`)
+If you wish to scale by the radius (not advised) you should do so using the `square` transformation (`SCALE size VIA square`)
 
 ### Examples
 
-#### Automatic use of date transform for x axis
+#### Automatic use of date transformation for x axis
 
 ```{ggsql}
 VISUALISE Date AS x, Temp AS y FROM ggsql:airquality


### PR DESCRIPTION
I think transformation might be the more standard choice here.  Just browsing the documentation - since this is such a promising, interesting project! 