### PR TITLE
Variable width/color/opacity lines

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -569,7 +569,9 @@ The codebase includes connection string parsing and feature flags for additional
 
 **Responsibility**: Convert DataFrame + Plot → output format (JSON, PNG, R code, etc.)
 
-#### Writer Trait (`mod.rs`)
+**Internal Architecture**: For Vega-Lite writer implementation details (unified dataset system, layer rendering pipeline, GeomRenderer lifecycle), see [`src/writer/vegalite/CLAUDE.md`](src/writer/vegalite/CLAUDE.md).
+
+#### Writer Trait
 
 ```rust
 pub trait Writer {
@@ -578,68 +580,13 @@ pub trait Writer {
 }
 ```
 
-#### Vega-Lite Writer (`vegalite.rs`)
+#### Available Writers
 
-**Current Production Writer** - Fully implemented and tested.
-
-**Features**:
-
-- Converts Plot → Vega-Lite JSON specification
-- Multi-layer composition support
-- Scale type → Vega field type mapping
-- Faceting (wrap and grid layouts)
-- Axis label customization
-- Inline data embedding
-
-**Architecture**:
-
-```rust
-impl Writer for VegaLiteWriter {
-    fn write(&self, df: &DataFrame, spec: &Plot) -> Result<String> {
-        // 1. Convert DataFrame to JSON values
-        let data_values = self.dataframe_to_json(df)?;
-
-        // 2. Build Vega-Lite spec
-        let mut vl_spec = json!({
-            "$schema": "https://vega.github.io/schema/vega-lite/v6.json",
-            "data": {"values": data_values},
-            "width": 600,
-            "autosize": {"type": "fit", "contains": "padding"}
-        });
-
-        // 3. Handle single vs multi-layer
-        if spec.layers.len() == 1 {
-            // Single layer: flat structure
-            vl_spec["mark"] = self.geom_to_mark(&spec.layers[0].geom);
-            vl_spec["encoding"] = self.build_encoding(&spec.layers[0], df, spec)?;
-        } else {
-            // Multi-layer: layered structure
-            let layers: Vec<Value> = spec.layers.iter()
-                .map(|layer| {
-                    let mut layer_spec = json!({
-                        "mark": self.geom_to_mark(&layer.geom),
-                        "encoding": self.build_encoding(layer, df, spec)?
-                    });
-                    // Apply axis labels to each layer
-                    apply_axis_labels(&mut layer_spec, &spec.labels);
-                    Ok(layer_spec)
-                })
-                .collect::<Result<Vec<_>>>()?;
-            vl_spec["layer"] = json!(layers);
-        }
-
-        // 4. Add faceting, title, etc.
-        self.add_faceting(&mut vl_spec, spec)?;
-        if let Some(labels) = &spec.labels {
-            if let Some(title) = labels.labels.get("title") {
-                vl_spec["title"] = json!(title);
-            }
-        }
-
-        Ok(serde_json::to_string_pretty(&vl_spec)?)
-    }
-}
-```
+**VegaLiteWriter** (Production-ready):
+- Generates Vega-Lite v6 JSON specifications
+- Multi-layer composition with unified dataset architecture
+- Full support for scales, faceting, projections, and labels
+- Automatic geom-specific optimizations (segmentation, decomposition)
 
 ---
 

--- a/doc/syntax/layer/type/line.qmd
+++ b/doc/syntax/layer/type/line.qmd
@@ -14,10 +14,10 @@ The following aesthetics are recognised by the line layer.
 * Secondary axis (e.g. `y`): The value of the dependent variable.
 
 ### Optional
-* `colour`/`stroke`: The colour of the line
-* `opacity`: The opacity of the line
-* `linewidth`: The width of the line
-* `linetype`: The type of line, i.e. the dashing pattern
+* `colour`/`stroke`: The colour of the line.
+* `opacity`: The opacity of the line.
+* `linewidth`: The width of the line. If `linewidth` varies within a group, `linetype` is incompatible.
+* `linetype`: The type of line, i.e. the dashing pattern.
 
 ## Settings
 * `position`: Position adjustment. One of `'identity'` (default), `'stack'`, `'dodge'`, or `'jitter'`
@@ -26,7 +26,9 @@ The following aesthetics are recognised by the line layer.
     * `'transposed'` to align the layer's primary axis with the coordinate system's second axis.
 
 ## Data transformation
-The line layer sorts the data along its primary axis.
+The line layer sorts the data along its primary axis. 
+If the line has a variable `stroke` or `opacity` aesthetic within groups, the line is broken into segments. 
+Each segment gets the property of the preceding datapoint, so the last datapoint in a group does not transfer these properties.
 
 ## Orientation
 Line plots are sorted and connected along their primary axis. Since the primary axis cannot be deduced from the mapping it must be specified using the `orientation` setting. If you wish to create a vertical line plot, you need to set `orientation => 'transposed'` to indicate that the primary layer axis follows the second axis of the coordinate system.  
@@ -50,10 +52,41 @@ DRAW line
   PARTITION BY Month
 ```
 
-or split them with an aesthetic
+or split them with a *discrete* aesthetic. 
+We can make a continuous variable (`Month`) discrete by using an ordinal scale.
 
 ```{ggsql}
 VISUALISE FROM ggsql:airquality
 DRAW line
-  MAPPING Day AS x, Temp AS y, Month AS color
+  MAPPING Day AS x, Temp AS y, Month AS stroke
+  SCALE ordinal stroke
+```
+
+When `stroke` or `opacity` varies, the properties of the preceding datapoint carry over. In the case below, we don't see the blue of the last datapoint.
+
+```{ggsql}
+WITH data(x, y, z) AS (VALUES
+  (1, 2, 1),
+  (2, 5, 3),
+  (3, 3, 5),
+)
+VISUALISE x, y FROM data
+DRAW line
+  MAPPING z AS stroke
+SCALE stroke TO ['red', 'green', 'blue']
+```
+
+The `linewidth` aesthetic can vary point to point.
+
+```{ggsql}
+WITH data(x, y, z) AS (VALUES
+  (1, 2, 1),
+  (2, 5, 3),
+  (3, 3, 5),
+)
+
+VISUALISE x, y FROM data
+DRAW line
+  MAPPING z AS linewidth
+SCALE linewidth TO [0, 30]
 ```

--- a/doc/syntax/layer/type/path.qmd
+++ b/doc/syntax/layer/type/path.qmd
@@ -14,16 +14,18 @@ The following aesthetics are recognised by the path layer.
 * Secondary axis (e.g. `y`): Position along the secondary axis.
 
 ### Optional
-* `colour`/`stroke`: The colour of the path
-* `opacity`: The opacity of the path
-* `linewidth`: The width of the path
-* `linetype`: The type of path, i.e. the dashing pattern
+* `colour`/`stroke`: The colour of the path.
+* `opacity`: The opacity of the path.
+* `linewidth`: The width of the path. If `linewidth` varies within a group, `linetype` is incompatible.
+* `linetype`: The type of path, i.e. the dashing pattern.
 
 ## Settings
 * `position`: Position adjustment. One of `'identity'` (default), `'stack'`, `'dodge'`, or `'jitter'`
 
 ## Data transformation
-The path layer does not transform its data but passes it through unchanged
+The path layer does not transform its data but passes it through unchanged.
+If the path has a variable `stroke` or `opacity` aesthetic within groups, the line is broken into segments. 
+Each segment gets the property of the preceding datapoint, so the last datapoint in a group does not transfer these properties.
 
 ## Orientation
 The path layer has no orientation. The axes are treated symmetrically.
@@ -86,4 +88,34 @@ DRAW polygon
   MAPPING 'Polygon' AS stroke
 DRAW path 
   MAPPING 'Path' AS stroke
+```
+
+When `stroke` or `opacity` varies, the properties of the preceding datapoint carry over. In the case below, we don't see the blue of the last datapoint.
+
+```{ggsql}
+WITH data(x, y, z) AS (VALUES
+  (1, 2, 1),
+  (3, 3, 3),
+  (2, 5, 5),
+)
+
+VISUALISE x, y FROM data
+DRAW path
+  MAPPING z AS stroke
+SCALE stroke TO ['red', 'green', 'blue']
+```
+
+The `linewidth` aesthetic can vary point to point.
+
+```{ggsql}
+WITH data(x, y, z) AS (VALUES
+  (1, 2, 1),
+  (3, 3, 3),
+  (2, 5, 5),
+)
+
+VISUALISE x, y FROM data
+DRAW path
+  MAPPING z AS linewidth
+SCALE linewidth TO [0, 30]
 ```

--- a/src/writer/vegalite/CLAUDE.md
+++ b/src/writer/vegalite/CLAUDE.md
@@ -1,0 +1,386 @@
+# Writer Module Internal Architecture
+
+This document describes internal implementation details of the Vega-Lite writer that are critical for extending or modifying layer rendering behavior.
+
+## Unified Dataset Architecture
+
+**Key Concept**: All layer data is merged into a single top-level dataset with source tagging.
+
+### Why Unified?
+
+Instead of each layer having its own named dataset, all data is combined into one array. This enables:
+- Shared axes and scales across layers
+- Simplified faceting (one dataset split across panels)
+- Consistent row indexing for ordering (line/path/polygon geoms)
+
+### How It Works
+
+```
+┌─────────────────────────────────────────────────────────┐
+│  Layer 0 DataFrame    │  Layer 1 DataFrame              │
+│  [row0, row1, row2]   │  [row0, row1]                   │
+└───────────────┬───────┴──────────────┬──────────────────┘
+                │                      │
+                ▼                      ▼
+         datasets[data_key_0]    datasets[data_key_1]
+                │                      │
+                └──────────┬───────────┘
+                           ▼
+                   unify_datasets()
+                           │
+                           ▼
+        ┌──────────────────────────────────────────┐
+        │  Unified Dataset (top-level data.values) │
+        │  [{...row, __ggsql_source__: key_0},     │
+        │   {...row, __ggsql_source__: key_0},     │
+        │   {...row, __ggsql_source__: key_0},     │
+        │   {...row, __ggsql_source__: key_1},     │
+        │   {...row, __ggsql_source__: key_1}]     │
+        └──────────────────────────────────────────┘
+                           │
+                           ▼
+        Each layer has source filter transform:
+        {"filter": {"field": "__ggsql_source__", "equal": "data_key"}}
+```
+
+### Source Tagging
+
+When `unify_datasets()` merges datasets:
+1. Adds `__ggsql_source__` column to each row with its dataset key
+2. Adds `__ggsql_row_index__` column for order preservation (0-indexed, global)
+3. Fills missing columns with `null` (union schema)
+
+Example:
+```json
+{
+  "__ggsql_aes_pos1__": 1,
+  "__ggsql_aes_pos2__": 2,
+  "__ggsql_source__": "__ggsql_layer_0__",
+  "__ggsql_row_index__": 0
+}
+```
+
+## Layer Building Pipeline
+
+### High-Level Flow
+
+```
+prepare_layer_data()
+    └─> renderer.prepare_data(df) → PreparedData
+            │
+            ▼
+    Register datasets:
+    - Single: datasets[data_key] = values
+    - Composite: datasets[data_key + component] = values for each component
+            │
+            ▼
+    unify_datasets(datasets) → unified array
+            │
+            ▼
+    vl_spec["data"] = {"values": unified}
+            │
+            ▼
+build_layers()
+    for each layer:
+        1. Create base layer_spec with mark
+        2. Add source filter transform (if renderer.needs_source_filter())
+        3. Build encoding channels
+        4. renderer.modify_spec(layer_spec) → modify mark properties
+        5. renderer.finalize(layer_spec) → add transforms, expand to multiple layers
+            │
+            ▼
+    Return array of layer specs
+```
+
+### PreparedData Semantics
+
+**PreparedData::Single**:
+```rust
+PreparedData::Single { values }
+```
+- Dataset registered as: `datasets[data_key] = values`
+- `__ggsql_source__` in unified data: `data_key`
+- Source filter: `{"field": "__ggsql_source__", "equal": "data_key"}`
+- **Use case**: Standard single-dataset layers (point, line, bar, etc.)
+
+**PreparedData::Composite**:
+```rust
+PreparedData::Composite {
+    components: HashMap<String, Vec<Value>>,  // component_name → values
+    metadata: Box<dyn Any>,
+}
+```
+- Datasets registered as: `datasets[data_key + component_name] = values` for each component
+- `__ggsql_source__` in unified data: `data_key + component_name`
+- **Use case**: Geoms that decompose into multiple sub-layers (boxplot, violin, errorbar)
+- **Special case**: Empty component name (`""`) creates `data_key + "" = data_key` (useful for passing metadata without changing dataset key)
+
+### Important Rules for Finalize
+
+**DO**:
+- ✅ Preserve existing transforms:
+  ```rust
+  let mut transforms = layer_spec
+      .get("transform")
+      .and_then(|t| t.as_array())
+      .cloned()
+      .unwrap_or_default();
+  // Add your transforms
+  transforms.extend(your_transforms);
+  layer_spec["transform"] = json!(transforms);
+  ```
+- ✅ Return multiple layers if needed (composite geoms)
+- ✅ Modify encodings that reference transformed fields
+
+**DON'T**:
+- ❌ Set `layer_spec["data"]` - layers use the unified top-level dataset
+- ❌ Replace the transforms array without preserving existing ones
+- ❌ Assume the layer is isolated - it shares data with other layers
+
+## GeomRenderer Trait Lifecycle
+
+### When Each Method Is Called
+
+```rust
+// 1. Data Preparation Phase (before unification)
+renderer.prepare_data(df, layer, data_key, binned_columns)
+    → PreparedData
+    // Context: You have the full DataFrame
+    // Can: Transform data, compute statistics, create metadata
+    // Returns: Data values + optional metadata
+
+// 2. Layer Spec Building Phase (after unification)
+let layer_spec = create_base_spec();
+add_source_filter(layer_spec);  // if needs_source_filter() == true
+build_encoding(layer_spec);
+
+renderer.modify_spec(layer_spec, layer, context)
+    // Context: Base spec created, encoding built
+    // Can: Modify mark properties, add mark-level calculations
+    // Example: Bar width, violin fill settings
+
+// 3. Finalization Phase
+renderer.finalize(layer_spec, layer, data_key, prepared)
+    → Vec<Value>  // Can return multiple layers
+    // Context: Complete layer spec with transforms and encoding
+    // Can: Add transforms, expand to multiple layers, modify encodings
+    // Must: Preserve existing transforms
+```
+
+### Method Purposes
+
+**`prepare_data`**:
+- Access full DataFrame before unification
+- Perform data transformations (e.g., create segment endpoints)
+- Compute statistics (e.g., boxplot quartiles)
+- Return metadata for later use
+
+**`modify_encoding`**:
+- Called during encoding construction (before spec is built)
+- Modify encoding channels (add detail, change field names)
+- Add geom-specific encoding logic (e.g., order for path/line)
+
+**`modify_spec`**:
+- Called after encoding is built but before finalize
+- Modify mark properties (width, baseline, etc.)
+- Add mark-level calculations
+
+**`needs_source_filter`**:
+- Return `false` if your geom handles filtering internally
+- Default: `true` (use standard source filter)
+- Example: Boxplot returns `false` and adds component-specific filters
+
+**`finalize`**:
+- Add Vega-Lite transforms (window, flatten, calculate)
+- Expand into multiple layers (composite geoms)
+- Modify encodings that reference transformed fields
+- Return final layer array
+
+## Common Patterns
+
+### Pattern 1: Single Layer with Transforms (Line Segmentation)
+
+```rust
+fn prepare_data(...) -> Result<PreparedData> {
+    // Detect if segmentation is needed
+    let needs_segmentation = check_within_group_variation(df);
+    
+    let values = dataframe_to_values(df)?;
+    
+    if needs_segmentation {
+        // Use Composite with empty component name to pass metadata
+        Ok(PreparedData::Composite {
+            components: [("".to_string(), values)].into_iter().collect(),
+            metadata: Box::new(SegmentMetadata { ... }),
+        })
+    } else {
+        Ok(PreparedData::Single { values })
+    }
+}
+
+fn finalize(...) -> Result<Vec<Value>> {
+    match prepared {
+        PreparedData::Composite { metadata, .. } => {
+            // Preserve existing transforms (source filter!)
+            let mut transforms = layer_spec
+                .get("transform")
+                .and_then(|t| t.as_array())
+                .cloned()
+                .unwrap_or_default();
+            
+            // Add segmentation transforms
+            transforms.extend(vec![
+                json!({"window": [...]}),
+                json!({"flatten": [...]}),
+                // ...
+            ]);
+            
+            layer_spec["transform"] = json!(transforms);
+            
+            // Don't set layer_spec["data"] - use unified dataset
+            
+            Ok(vec![layer_spec])
+        }
+        PreparedData::Single { .. } => Ok(vec![layer_spec])
+    }
+}
+```
+
+### Pattern 2: Multi-Layer Decomposition (Boxplot)
+
+```rust
+fn prepare_data(...) -> Result<PreparedData> {
+    // Compute boxplot statistics
+    let components = compute_boxplot_components(df);
+    
+    // Return multiple component datasets
+    Ok(PreparedData::Composite {
+        components: [
+            ("box".to_string(), box_values),
+            ("median".to_string(), median_values),
+            ("whisker_lower".to_string(), whisker_values),
+            // ...
+        ].into_iter().collect(),
+        metadata: Box::new(BoxplotMetadata { has_outliers }),
+    })
+}
+
+fn needs_source_filter() -> bool {
+    // We'll add component-specific filters ourselves
+    false
+}
+
+fn finalize(...) -> Result<Vec<Value>> {
+    // Create separate layer for each component
+    let mut layers = Vec::new();
+    
+    // Box layer
+    let mut box_layer = layer_spec.clone();
+    box_layer["transform"] = json!([{
+        "filter": {
+            "field": "__ggsql_source__",
+            "equal": format!("{}box", data_key)  // Component-specific filter
+        }
+    }]);
+    layers.push(box_layer);
+    
+    // Median layer
+    let mut median_layer = create_median_layer();
+    median_layer["transform"] = json!([{
+        "filter": {
+            "field": "__ggsql_source__",
+            "equal": format!("{}median", data_key)
+        }
+    }]);
+    layers.push(median_layer);
+    
+    // ... more layers
+    
+    Ok(layers)
+}
+```
+
+### Pattern 3: Mark Property Modification (Bar Width)
+
+```rust
+fn modify_spec(...) -> Result<()> {
+    let width = layer.parameters.get("width")
+        .and_then(|v| v.as_number())
+        .unwrap_or(0.9);
+    
+    layer_spec["mark"] = json!({
+        "type": "bar",
+        "width": {"band": width},
+        "clip": true
+    });
+    
+    Ok(())
+}
+```
+
+## Debugging Tips
+
+### Issue: Layer has no data / nothing renders
+
+**Check**:
+1. Is `__ggsql_source__` value correct in unified data?
+   - For Single: should match `data_key`
+   - For Composite: should match `data_key + component_name`
+2. Does layer have source filter transform?
+   - Check `layer_spec["transform"][0]` for filter
+   - If using Composite, ensure component name matches
+3. Did you accidentally set `layer_spec["data"]`?
+   - Remove it - layers use unified top-level dataset
+
+**Debug**:
+```rust
+eprintln!("Dataset key: {}", data_key);
+eprintln!("Source values in data: {:?}", 
+    unified_data.iter()
+        .filter_map(|row| row.get("__ggsql_source__"))
+        .collect::<Vec<_>>());
+eprintln!("Layer transforms: {:?}", layer_spec["transform"]);
+```
+
+### Issue: Transforms not working correctly
+
+**Check**:
+1. Are you preserving existing transforms in finalize?
+2. Are transform fields available in the data?
+3. Is filter ordering correct? (source filter should come first)
+
+### Issue: Composite geom breaks with wrong source keys
+
+**Solution**: Use empty component name (`""`) if you want `data_key` as the source value:
+```rust
+PreparedData::Composite {
+    components: [("".to_string(), values)].into_iter().collect(),
+    metadata: Box::new(YourMetadata { ... }),
+}
+```
+
+## Testing Rendered Output
+
+To inspect generated Vega-Lite specs:
+
+```bash
+# Generate spec to file
+cargo run --bin ggsql -- exec "YOUR QUERY" \
+    --reader "duckdb://memory" \
+    --output /tmp/test.vl.json
+
+# Check structure
+grep -A10 '"data"' /tmp/test.vl.json  # Top-level data
+grep -A5 '"transform"' /tmp/test.vl.json  # Layer transforms
+grep '__ggsql_source__' /tmp/test.vl.json  # Source values
+```
+
+Paste the spec into [Vega-Lite Editor](https://vega.github.io/editor/#/url/vega-lite/) to visualize.
+
+## References
+
+- **Main implementation**: `src/writer/vegalite/mod.rs`
+- **Layer rendering**: `src/writer/vegalite/layer.rs`
+- **Data unification**: `src/writer/vegalite/data.rs` (`unify_datasets()`)
+- **Renderer trait**: `src/writer/vegalite/layer.rs` (`GeomRenderer` trait)
+- **Example renderers**: `LineRenderer`, `BoxplotRenderer`, `ViolinRenderer` in `layer.rs`

--- a/src/writer/vegalite/layer.rs
+++ b/src/writer/vegalite/layer.rs
@@ -109,7 +109,10 @@ pub fn validate_layer_columns(layer: &Layer, data: &DataFrame, layer_idx: usize)
 /// Data prepared for a layer - either single dataset or multiple components
 pub enum PreparedData {
     /// Standard single dataset (most geoms)
-    Single { values: Vec<Value> },
+    Single {
+        values: Vec<Value>,
+        metadata: Box<dyn Any + Send + Sync>,
+    },
     /// Multiple component datasets (boxplot, violin, errorbar)
     Composite {
         components: HashMap<String, Vec<Value>>,
@@ -198,7 +201,7 @@ pub trait GeomRenderer: Send + Sync {
         } else {
             dataframe_to_values_with_bins(df, binned_columns)?
         };
-        Ok(PreparedData::Single { values })
+        Ok(PreparedData::Single { values, metadata: Box::new(()) })
     }
 
     // === Phase 2: Encoding Modifications ===
@@ -478,16 +481,10 @@ impl GeomRenderer for LineRenderer {
 
         let needs_segmentation = !varying_aesthetics.is_empty();
 
-        if needs_segmentation {
-            // Use Composite with empty component name so dataset key = data_key (not data_key + suffix)
-            // This ensures the source filter works correctly with the unified dataset
-            Ok(PreparedData::Composite {
-                components: [("".to_string(), values)].iter().cloned().collect(),
-                metadata: Box::new(()),
-            })
-        } else {
-            Ok(PreparedData::Single { values })
-        }
+        Ok(PreparedData::Single {
+            values,
+            metadata: Box::new(needs_segmentation),
+        })
     }
 
     fn modify_encoding(
@@ -512,10 +509,19 @@ impl GeomRenderer for LineRenderer {
         _data_key: &str,
         prepared: &PreparedData,
     ) -> Result<Vec<Value>> {
-        // Early return for standard line rendering
-        let PreparedData::Composite { .. } = prepared else {
-            return Ok(vec![layer_spec]);
+        // Check if segmentation is needed via metadata
+        let PreparedData::Single { metadata, .. } = prepared else {
+            return Err(GgsqlError::InternalError(
+                "LineRenderer expects PreparedData::Single".to_string(),
+            ));
         };
+
+        let needs_segmentation = metadata.downcast_ref::<bool>() == Some(&true);
+
+        // Early return for standard line rendering
+        if !needs_segmentation {
+            return Ok(vec![layer_spec]);
+        }
 
         // Get position column names
         let x_col = naming::aesthetic_column("pos1");

--- a/src/writer/vegalite/layer.rs
+++ b/src/writer/vegalite/layer.rs
@@ -201,7 +201,10 @@ pub trait GeomRenderer: Send + Sync {
         } else {
             dataframe_to_values_with_bins(df, binned_columns)?
         };
-        Ok(PreparedData::Single { values, metadata: Box::new(()) })
+        Ok(PreparedData::Single {
+            values,
+            metadata: Box::new(()),
+        })
     }
 
     // === Phase 2: Encoding Modifications ===
@@ -629,10 +632,13 @@ impl GeomRenderer for PathRenderer {
                 }
 
                 // Add segment_id to detail encoding
-                encoding_map.insert("detail".to_string(), json!({
-                    "field": "__segment_id__",
-                    "type": "nominal"
-                }));
+                encoding_map.insert(
+                    "detail".to_string(),
+                    json!({
+                        "field": "__segment_id__",
+                        "type": "nominal"
+                    }),
+                );
             }
         }
 
@@ -4310,7 +4316,9 @@ mod tests {
         let spec = &result[0];
 
         // Check transforms exist
-        let transforms = spec["transform"].as_array().expect("Should have transforms");
+        let transforms = spec["transform"]
+            .as_array()
+            .expect("Should have transforms");
         assert!(!transforms.is_empty());
 
         // Check for window transform (lead operation)
@@ -4323,26 +4331,22 @@ mod tests {
 
         // Check for detail encoding with segment_id
         let encoding = spec["encoding"].as_object().unwrap();
-        assert!(encoding.contains_key("detail"), "Should have detail encoding");
+        assert!(
+            encoding.contains_key("detail"),
+            "Should have detail encoding"
+        );
         assert_eq!(
-            encoding["detail"]["field"],
-            "__segment_id__",
+            encoding["detail"]["field"], "__segment_id__",
             "Detail should use segment_id"
         );
 
         // Check that x/y use _final fields
         assert!(
-            encoding["x"]["field"]
-                .as_str()
-                .unwrap()
-                .ends_with("_final"),
+            encoding["x"]["field"].as_str().unwrap().ends_with("_final"),
             "x should use _final field"
         );
         assert!(
-            encoding["y"]["field"]
-                .as_str()
-                .unwrap()
-                .ends_with("_final"),
+            encoding["y"]["field"].as_str().unwrap().ends_with("_final"),
             "y should use _final field"
         );
     }

--- a/src/writer/vegalite/layer.rs
+++ b/src/writer/vegalite/layer.rs
@@ -334,32 +334,29 @@ impl GeomRenderer for PathRenderer {
 // Line Renderer
 // =============================================================================
 
-/// Find indices where group values change in a DataFrame
+/// Find row indices where any of the specified columns change value.
 ///
-/// Returns a sorted vector of indices marking group boundaries. The first element
-/// is always 0 (start of first group), followed by indices where any of the
-/// group columns change value.
-fn find_group_boundaries(df: &DataFrame, group_columns: &[String]) -> Result<Vec<usize>> {
+/// Returns a sorted vector starting with 0 (first row), followed by indices
+/// where any column value differs from the previous row. Does not include
+/// the final boundary (n_rows).
+///
+/// Used by both line segmentation and text font run-length encoding.
+fn find_change_starts(df: &DataFrame, columns: &[String]) -> Result<Vec<usize>> {
     use polars::prelude::*;
 
     let n_rows = df.height();
 
-    if group_columns.is_empty() {
-        // No grouping: treat entire dataset as one group
-        return Ok(vec![0, n_rows]);
-    }
-
-    if n_rows <= 1 {
-        return Ok(vec![0, n_rows]);
+    if columns.is_empty() || n_rows <= 1 {
+        return Ok(vec![0]);
     }
 
     // Initialize change mask as all false (no changes)
     let mut change_mask = BooleanChunked::full("change_mask".into(), false, n_rows - 1);
 
-    // For each group column, OR its change mask into the accumulator
-    for col_name in group_columns {
+    // For each column, OR its change mask into the accumulator
+    for col_name in columns {
         let series = df.column(col_name).map_err(|e| {
-            GgsqlError::InternalError(format!("Group column '{}' not found: {}", col_name, e))
+            GgsqlError::InternalError(format!("Column '{}' not found: {}", col_name, e))
         })?;
 
         // Compare each row with the previous row
@@ -377,17 +374,14 @@ fn find_group_boundaries(df: &DataFrame, group_columns: &[String]) -> Result<Vec
     }
 
     // Extract indices where mask is true (offset by 1 since we compared with previous)
-    let mut boundaries = vec![0];
+    let mut change_starts = vec![0];
     for (idx, changed) in change_mask.into_iter().enumerate() {
         if changed == Some(true) {
-            boundaries.push(idx + 1);
+            change_starts.push(idx + 1);
         }
     }
 
-    // Add final boundary (end of data)
-    boundaries.push(n_rows);
-
-    Ok(boundaries)
+    Ok(change_starts)
 }
 
 /// Check if an aesthetic varies within any group segment
@@ -472,7 +466,14 @@ impl GeomRenderer for LineRenderer {
             .collect();
 
         // Compute group boundaries once (without the material aesthetics)
-        let group_boundaries = find_group_boundaries(df, &partition_columns)?;
+        let n_rows = df.height();
+        let group_boundaries = if partition_columns.is_empty() || n_rows <= 1 {
+            vec![0, n_rows]
+        } else {
+            let mut boundaries = find_change_starts(df, &partition_columns)?;
+            boundaries.push(n_rows);
+            boundaries
+        };
 
         // Check each mapped material aesthetic for within-group variation
         for (aesthetic, col) in &mapped_material_aesthetics {
@@ -871,43 +872,29 @@ impl TextRenderer {
             return Ok((DataFrame::default(), Vec::new()));
         }
 
-        // Build boolean mask showing where any font property changes
-        let mut changed = BooleanChunked::full("changed".into(), false, nrows);
-        let mut font_columns: HashMap<&str, &polars::prelude::Column> = HashMap::new();
-
-        for aesthetic in [
+        // Collect font property column names that exist in the DataFrame
+        let font_aesthetics = [
             "typeface",
             "fontweight",
             "italic",
             "hjust",
             "vjust",
             "rotation",
-        ] {
-            if let Ok(col) = df.column(&naming::aesthetic_column(aesthetic)) {
-                let col_changed = col.not_equal(&col.shift(1)).map_err(|e| {
-                    GgsqlError::InternalError(format!("Failed to compare column: {}", e))
-                })?;
-                changed = &changed | &col_changed;
+        ];
+
+        let mut font_column_names = Vec::new();
+        let mut font_columns: HashMap<&str, &polars::prelude::Column> = HashMap::new();
+
+        for aesthetic in font_aesthetics {
+            let col_name = naming::aesthetic_column(aesthetic);
+            if let Ok(col) = df.column(&col_name) {
+                font_column_names.push(col_name);
                 font_columns.insert(aesthetic, col);
             }
         }
 
-        // Extract change indices (where mask is true)
-        // shift() creates nulls at position 0, which we treat as a change point
-        let mut change_indices: Vec<usize> = Vec::new();
-        for (i, val) in changed.iter().enumerate() {
-            if val == Some(true) || val.is_none() {
-                // Treat null (from shift) or true as change point
-                change_indices.push(i);
-            }
-        }
-
-        // First row is always a change point (shift comparison is null)
-        if !change_indices.is_empty() && change_indices[0] != 0 {
-            change_indices.insert(0, 0);
-        } else if change_indices.is_empty() {
-            change_indices.push(0);
-        }
+        // Find indices where any font property changes
+        let change_indices = find_change_starts(df, &font_column_names)?;
 
         // Calculate run lengths
         let run_lengths: Vec<usize> = change_indices
@@ -924,14 +911,6 @@ impl TextRenderer {
             "indices".into(),
             change_indices.iter().map(|&i| i as u32).collect(),
         );
-        let font_aesthetics = [
-            "typeface",
-            "fontweight",
-            "italic",
-            "hjust",
-            "vjust",
-            "rotation",
-        ];
 
         let mut result_cols = Vec::new();
         for aesthetic in font_aesthetics {

--- a/src/writer/vegalite/layer.rs
+++ b/src/writer/vegalite/layer.rs
@@ -441,7 +441,7 @@ impl GeomRenderer for LineRenderer {
     ) -> Result<PreparedData> {
         // Continuous material aesthetics that can trigger segmentation
         // (linetype is always discrete and already handled via partition_by)
-        let material_aesthetics = ["stroke", "linewidth"];
+        let material_aesthetics: &[&'static str] = &["stroke", "linewidth"];
 
         // Start with existing partition_by (includes discrete material aesthetics already)
         let partition_columns: Vec<String> = layer.partition_by.clone();
@@ -457,9 +457,9 @@ impl GeomRenderer for LineRenderer {
         };
 
         // Check continuous material aesthetics (not in partition_by) for within-group variation
-        let mut varying_aesthetics: Vec<&str> = Vec::new();
+        let mut varying_aesthetics: Vec<&'static str> = Vec::new();
 
-        for aesthetic in material_aesthetics {
+        for &aesthetic in material_aesthetics {
             if let Some(AestheticValue::Column { name: col, .. }) = layer.mappings.get(aesthetic) {
                 // Skip if already in partition_by (discrete, already defines groups)
                 if !layer.partition_by.contains(col) {
@@ -479,11 +479,9 @@ impl GeomRenderer for LineRenderer {
             dataframe_to_values_with_bins(df, binned_columns)?
         };
 
-        let needs_segmentation = !varying_aesthetics.is_empty();
-
         Ok(PreparedData::Single {
             values,
-            metadata: Box::new(needs_segmentation),
+            metadata: Box::new(varying_aesthetics),
         })
     }
 
@@ -516,20 +514,54 @@ impl GeomRenderer for LineRenderer {
             ));
         };
 
-        let needs_segmentation = metadata.downcast_ref::<bool>() == Some(&true);
+        // Get varying aesthetics from metadata
+        let Some(varying_aesthetics) = metadata.downcast_ref::<Vec<&'static str>>() else {
+            return Ok(vec![layer_spec]);
+        };
 
-        // Early return for standard line rendering
-        if !needs_segmentation {
+        // Handle varying linewidth: switch to trail mark and translate encodings
+        if varying_aesthetics.contains(&"linewidth") {
+            layer_spec["mark"] = json!({"type": "trail", "clip": true, "stroke": null});
+
+            // Translate line encodings to trail encodings
+            if let Some(encoding_obj) = layer_spec.get_mut("encoding") {
+                if let Some(encoding_map) = encoding_obj.as_object_mut() {
+                    // strokeWidth → size
+                    if let Some(stroke_width) = encoding_map.remove("strokeWidth") {
+                        encoding_map.insert("size".to_string(), stroke_width);
+                    }
+
+                    // stroke → fill
+                    if let Some(stroke) = encoding_map.remove("stroke") {
+                        encoding_map.insert("fill".to_string(), stroke);
+                    }
+
+                    // opacity → fillOpacity
+                    if let Some(opacity) = encoding_map.remove("opacity") {
+                        encoding_map.insert("fillOpacity".to_string(), opacity);
+                    }
+                }
+            }
+        }
+
+        // Handle varying stroke: apply segmentation
+        if !varying_aesthetics.contains(&"stroke") {
+            // Only linewidth varies, trail mark handles it natively
             return Ok(vec![layer_spec]);
         }
 
-        // Get position column names
-        let x_col = naming::aesthetic_column("pos1");
-        let y_col = naming::aesthetic_column("pos2");
+        // Build list of fields to segment (always x/y, plus size if linewidth varies)
+        let mut segment_fields = vec![
+            ("x", naming::aesthetic_column("pos1")),
+            ("y", naming::aesthetic_column("pos2")),
+        ];
+        if varying_aesthetics.contains(&"linewidth") {
+            segment_fields.push(("size", naming::aesthetic_column("linewidth")));
+        }
 
         // Segmented rendering using detail encoding:
         // 1. Create segment IDs (row_index serves as segment ID)
-        // 2. Create next row's x/y values using window transform
+        // 2. Create next row's values using window transform
         // 3. Flatten to create 2 rows per segment (point_index: 0=start, 1=end)
         // 4. Use calculate to pick current or next based on point_index
         // 5. Add segment ID to detail encoding
@@ -542,18 +574,16 @@ impl GeomRenderer for LineRenderer {
             .unwrap_or_default();
 
         // Step 1 & 2: Window transform to get next row's values
-        let window_ops = vec![
-            json!({
-                "op": "lead",
-                "field": x_col,
-                "as": format!("{}_next", x_col)
-            }),
-            json!({
-                "op": "lead",
-                "field": y_col,
-                "as": format!("{}_next", y_col)
-            }),
-        ];
+        let window_ops: Vec<Value> = segment_fields
+            .iter()
+            .map(|(_, field)| {
+                json!({
+                    "op": "lead",
+                    "field": field,
+                    "as": format!("{}_next", field)
+                })
+            })
+            .collect();
 
         let mut window_transform = json!({
             "window": window_ops,
@@ -567,8 +597,10 @@ impl GeomRenderer for LineRenderer {
         transforms.push(window_transform);
 
         // Step 2b: Filter out last row in each group (no next point)
+        // Check the first field (x) for null to detect end of segments
+        let first_field = &segment_fields[0].1;
         transforms.push(json!({
-            "filter": format!("datum.{}_next != null", x_col)
+            "filter": format!("datum.{}_next != null", first_field)
         }));
 
         // Step 3: Flatten to create 2 rows per segment
@@ -583,16 +615,13 @@ impl GeomRenderer for LineRenderer {
             "as": ["__point_index__"]
         }));
 
-        // Step 4: Calculate actual x/y based on point_index
-        transforms.push(json!({
-            "calculate": format!("datum.__point_index__ == 0 ? datum.{} : datum.{}_next", x_col, x_col),
-            "as": format!("{}_final", x_col)
-        }));
-
-        transforms.push(json!({
-            "calculate": format!("datum.__point_index__ == 0 ? datum.{} : datum.{}_next", y_col, y_col),
-            "as": format!("{}_final", y_col)
-        }));
+        // Step 4: Calculate actual field values based on point_index
+        for (_, field) in &segment_fields {
+            transforms.push(json!({
+                "calculate": format!("datum.__point_index__ == 0 ? datum.{} : datum.{}_next", field, field),
+                "as": format!("{}_final", field)
+            }));
+        }
 
         // Step 5: Create segment ID (use original row_index)
         transforms.push(json!({
@@ -604,20 +633,15 @@ impl GeomRenderer for LineRenderer {
         // Don't set layer_spec["data"] - use the unified top-level dataset
         // The source filter transform will select the correct rows
 
-        // Update encodings to use final x/y and add segment_id to detail
+        // Update encodings to use final field values and add segment_id to detail
         if let Some(encoding_obj) = layer_spec.get_mut("encoding") {
             if let Some(encoding_map) = encoding_obj.as_object_mut() {
-                // Update x encoding to use x_final
-                if let Some(x_enc) = encoding_map.get_mut("x") {
-                    if let Some(x_obj) = x_enc.as_object_mut() {
-                        x_obj.insert("field".to_string(), json!(format!("{}_final", x_col)));
-                    }
-                }
-
-                // Update y encoding to use y_final
-                if let Some(y_enc) = encoding_map.get_mut("y") {
-                    if let Some(y_obj) = y_enc.as_object_mut() {
-                        y_obj.insert("field".to_string(), json!(format!("{}_final", y_col)));
+                // Update each field encoding to use _final
+                for (encoding_name, field) in &segment_fields {
+                    if let Some(enc) = encoding_map.get_mut(*encoding_name) {
+                        if let Some(enc_obj) = enc.as_object_mut() {
+                            enc_obj.insert("field".to_string(), json!(format!("{}_final", field)));
+                        }
                     }
                 }
 

--- a/src/writer/vegalite/layer.rs
+++ b/src/writer/vegalite/layer.rs
@@ -4163,4 +4163,187 @@ mod tests {
             "Error message should mention conflicting aesthetics"
         );
     }
+
+    #[test]
+    fn test_path_renderer_varying_aesthetics_metadata() {
+        use crate::plot::{AestheticValue, Geom, Layer};
+        use polars::prelude::*;
+
+        let renderer = PathRenderer;
+        let mut layer = Layer::new(Geom::line());
+
+        // Create DataFrame with varying stroke
+        let df = df! {
+            naming::aesthetic_column("pos1").as_str() => &[1.0, 2.0, 3.0],
+            naming::aesthetic_column("pos2").as_str() => &[10.0, 20.0, 30.0],
+            "color".to_string().as_str() => &[1.0, 2.0, 3.0],
+        }
+        .unwrap();
+
+        // Map stroke to color column (continuous, not in partition_by)
+        layer.mappings.insert(
+            "stroke".to_string(),
+            AestheticValue::standard_column("color"),
+        );
+
+        // Prepare data - should detect varying stroke
+        let prepared = renderer
+            .prepare_data(&df, &layer, "test", &HashMap::new())
+            .unwrap();
+
+        match prepared {
+            PreparedData::Single { metadata, .. } => {
+                let varying_aesthetics = metadata
+                    .downcast_ref::<Vec<&'static str>>()
+                    .expect("Metadata should be Vec<&str>");
+                assert_eq!(varying_aesthetics.len(), 1);
+                assert!(varying_aesthetics.contains(&"stroke"));
+            }
+            _ => panic!("Expected Single variant"),
+        }
+    }
+
+    #[test]
+    fn test_path_renderer_trail_mark_for_varying_linewidth() {
+        use crate::plot::{AestheticValue, Geom, Layer};
+        use polars::prelude::*;
+
+        let renderer = PathRenderer;
+        let mut layer = Layer::new(Geom::line());
+
+        // Create DataFrame with varying linewidth
+        let df = df! {
+            naming::aesthetic_column("pos1").as_str() => &[1.0, 2.0, 3.0],
+            naming::aesthetic_column("pos2").as_str() => &[10.0, 20.0, 30.0],
+            naming::aesthetic_column("linewidth").as_str() => &[1.0, 3.0, 5.0],
+        }
+        .unwrap();
+
+        // Map linewidth to column
+        layer.mappings.insert(
+            "linewidth".to_string(),
+            AestheticValue::standard_column(naming::aesthetic_column("linewidth")),
+        );
+
+        // Prepare data
+        let prepared = renderer
+            .prepare_data(&df, &layer, "test", &HashMap::new())
+            .unwrap();
+
+        // Create a mock layer spec
+        let layer_spec = json!({
+            "mark": {"type": "line", "clip": true},
+            "encoding": {
+                "x": {"field": naming::aesthetic_column("pos1"), "type": "quantitative"},
+                "y": {"field": naming::aesthetic_column("pos2"), "type": "quantitative"},
+                "strokeWidth": {"field": naming::aesthetic_column("linewidth"), "type": "quantitative"}
+            }
+        });
+
+        // Finalize should switch to trail mark and translate encodings
+        let result = renderer
+            .finalize(layer_spec.clone(), &layer, "test", &prepared)
+            .unwrap();
+
+        assert_eq!(result.len(), 1);
+        let spec = &result[0];
+
+        // Check mark type is trail
+        assert_eq!(spec["mark"]["type"], "trail");
+        assert_eq!(spec["mark"]["stroke"], json!(null));
+
+        // Check encoding translations
+        let encoding = spec["encoding"].as_object().unwrap();
+        assert!(encoding.contains_key("size"), "Should have size encoding");
+        assert!(
+            !encoding.contains_key("strokeWidth"),
+            "strokeWidth should be removed"
+        );
+        // No stroke mapping in this test, so no fill expected
+        assert!(!encoding.contains_key("stroke"), "stroke should be removed");
+    }
+
+    #[test]
+    fn test_path_renderer_segmentation_for_varying_stroke() {
+        use crate::plot::{AestheticValue, Geom, Layer};
+        use polars::prelude::*;
+
+        let renderer = PathRenderer;
+        let mut layer = Layer::new(Geom::line());
+
+        // Create DataFrame with varying stroke
+        let df = df! {
+            naming::aesthetic_column("pos1").as_str() => &[1.0, 2.0, 3.0],
+            naming::aesthetic_column("pos2").as_str() => &[10.0, 20.0, 30.0],
+            "color".to_string().as_str() => &[1.0, 2.0, 3.0],
+            ROW_INDEX_COLUMN => &[0, 1, 2],
+        }
+        .unwrap();
+
+        // Map stroke to color column
+        layer.mappings.insert(
+            "stroke".to_string(),
+            AestheticValue::standard_column("color"),
+        );
+
+        // Prepare data
+        let prepared = renderer
+            .prepare_data(&df, &layer, "test", &HashMap::new())
+            .unwrap();
+
+        // Create a mock layer spec
+        let layer_spec = json!({
+            "mark": {"type": "line", "clip": true},
+            "encoding": {
+                "x": {"field": naming::aesthetic_column("pos1"), "type": "quantitative"},
+                "y": {"field": naming::aesthetic_column("pos2"), "type": "quantitative"},
+                "stroke": {"field": "color", "type": "nominal"}
+            }
+        });
+
+        // Finalize should apply segmentation transforms
+        let result = renderer
+            .finalize(layer_spec.clone(), &layer, "test", &prepared)
+            .unwrap();
+
+        assert_eq!(result.len(), 1);
+        let spec = &result[0];
+
+        // Check transforms exist
+        let transforms = spec["transform"].as_array().expect("Should have transforms");
+        assert!(!transforms.is_empty());
+
+        // Check for window transform (lead operation)
+        let has_window = transforms.iter().any(|t| t.get("window").is_some());
+        assert!(has_window, "Should have window transform for lead");
+
+        // Check for flatten transform
+        let has_flatten = transforms.iter().any(|t| t.get("flatten").is_some());
+        assert!(has_flatten, "Should have flatten transform");
+
+        // Check for detail encoding with segment_id
+        let encoding = spec["encoding"].as_object().unwrap();
+        assert!(encoding.contains_key("detail"), "Should have detail encoding");
+        assert_eq!(
+            encoding["detail"]["field"],
+            "__segment_id__",
+            "Detail should use segment_id"
+        );
+
+        // Check that x/y use _final fields
+        assert!(
+            encoding["x"]["field"]
+                .as_str()
+                .unwrap()
+                .ends_with("_final"),
+            "x should use _final field"
+        );
+        assert!(
+            encoding["y"]["field"]
+                .as_str()
+                .unwrap()
+                .ends_with("_final"),
+            "y should use _final field"
+        );
+    }
 }

--- a/src/writer/vegalite/layer.rs
+++ b/src/writer/vegalite/layer.rs
@@ -404,7 +404,7 @@ fn aesthetic_varies_within_groups(
         }
 
         // Slice the series for this group and check uniqueness
-        let segment = series.slice(start as i64, (end - start) as usize);
+        let segment = series.slice(start as i64, end - start);
         let n_unique = segment.n_unique().map_err(|e| {
             GgsqlError::InternalError(format!("Failed to count unique values: {}", e))
         })?;

--- a/src/writer/vegalite/layer.rs
+++ b/src/writer/vegalite/layer.rs
@@ -425,7 +425,7 @@ fn aesthetic_varies_within_groups(
 
 /// Renderer for line geom - preserves data order for correct line rendering
 ///
-/// Automatically detects when continuous material aesthetics (stroke, linewidth) vary
+/// Automatically detects when continuous material aesthetics (stroke, linewidth, opacity) vary
 /// within partition groups and converts to segmented rendering using detail encoding.
 /// Discrete material aesthetics (linetype, or discrete stroke) already define groups
 /// via partition_by and don't require special handling.
@@ -441,7 +441,7 @@ impl GeomRenderer for LineRenderer {
     ) -> Result<PreparedData> {
         // Continuous material aesthetics that can trigger segmentation
         // (linetype is always discrete and already handled via partition_by)
-        let material_aesthetics: &[&'static str] = &["stroke", "linewidth"];
+        let material_aesthetics: &[&'static str] = &["stroke", "linewidth", "opacity"];
 
         // Start with existing partition_by (includes discrete material aesthetics already)
         let partition_columns: Vec<String> = layer.partition_by.clone();
@@ -544,8 +544,8 @@ impl GeomRenderer for LineRenderer {
             }
         }
 
-        // Handle varying stroke: apply segmentation
-        if !varying_aesthetics.contains(&"stroke") {
+        // Handle varying stroke/opacity: apply segmentation
+        if !varying_aesthetics.contains(&"stroke") && !varying_aesthetics.contains(&"opacity") {
             // Only linewidth varies, trail mark handles it natively
             return Ok(vec![layer_spec]);
         }

--- a/src/writer/vegalite/layer.rs
+++ b/src/writer/vegalite/layer.rs
@@ -314,27 +314,18 @@ impl GeomRenderer for BarRenderer {
 // Path Renderer
 // =============================================================================
 
-/// Renderer for path geom - adds order channel for natural data order
+/// Renderer for path and line geoms - preserves data order for correct rendering
+///
+/// Automatically detects when continuous material aesthetics (stroke, linewidth, opacity) vary
+/// within partition groups and converts to segmented rendering using detail encoding.
+/// Discrete material aesthetics (linetype, or discrete stroke) already define groups
+/// via partition_by and don't require special handling.
+///
+/// Handles both `line` and `path` geoms - the only difference is the mark type used.
 pub struct PathRenderer;
 
-impl GeomRenderer for PathRenderer {
-    fn modify_encoding(
-        &self,
-        encoding: &mut Map<String, Value>,
-        _layer: &Layer,
-        _context: &RenderContext,
-    ) -> Result<()> {
-        // Use row index field to preserve natural data order
-        encoding.insert(
-            "order".to_string(),
-            json!({"field": ROW_INDEX_COLUMN, "type": "quantitative"}),
-        );
-        Ok(())
-    }
-}
-
 // =============================================================================
-// Line Renderer
+// Helper functions for path/line segmentation
 // =============================================================================
 
 /// Find row indices where any of the specified columns change value.
@@ -423,15 +414,7 @@ fn aesthetic_varies_within_groups(
     Ok(false)
 }
 
-/// Renderer for line geom - preserves data order for correct line rendering
-///
-/// Automatically detects when continuous material aesthetics (stroke, linewidth, opacity) vary
-/// within partition groups and converts to segmented rendering using detail encoding.
-/// Discrete material aesthetics (linetype, or discrete stroke) already define groups
-/// via partition_by and don't require special handling.
-pub struct LineRenderer;
-
-impl GeomRenderer for LineRenderer {
+impl GeomRenderer for PathRenderer {
     fn prepare_data(
         &self,
         df: &DataFrame,
@@ -507,10 +490,10 @@ impl GeomRenderer for LineRenderer {
         _data_key: &str,
         prepared: &PreparedData,
     ) -> Result<Vec<Value>> {
-        // Check if segmentation is needed via metadata
+        // Get metadata from prepared data
         let PreparedData::Single { metadata, .. } = prepared else {
             return Err(GgsqlError::InternalError(
-                "LineRenderer expects PreparedData::Single".to_string(),
+                "PathRenderer expects PreparedData::Single".to_string(),
             ));
         };
 
@@ -2207,7 +2190,7 @@ impl GeomRenderer for BoxplotRenderer {
 pub fn get_renderer(geom: &Geom) -> Box<dyn GeomRenderer> {
     match geom.geom_type() {
         GeomType::Path => Box::new(PathRenderer),
-        GeomType::Line => Box::new(LineRenderer),
+        GeomType::Line => Box::new(PathRenderer),
         GeomType::Bar => Box::new(BarRenderer),
         GeomType::Rect => Box::new(RectRenderer),
         GeomType::Ribbon => Box::new(RibbonRenderer),

--- a/src/writer/vegalite/layer.rs
+++ b/src/writer/vegalite/layer.rs
@@ -334,10 +334,180 @@ impl GeomRenderer for PathRenderer {
 // Line Renderer
 // =============================================================================
 
+/// Find indices where group values change in a DataFrame
+///
+/// Returns a sorted vector of indices marking group boundaries. The first element
+/// is always 0 (start of first group), followed by indices where any of the
+/// group columns change value.
+fn find_group_boundaries(df: &DataFrame, group_columns: &[String]) -> Result<Vec<usize>> {
+    use polars::prelude::*;
+
+    let n_rows = df.height();
+
+    if group_columns.is_empty() {
+        // No grouping: treat entire dataset as one group
+        return Ok(vec![0, n_rows]);
+    }
+
+    if n_rows <= 1 {
+        return Ok(vec![0, n_rows]);
+    }
+
+    // Initialize change mask as all false (no changes)
+    let mut change_mask = BooleanChunked::full("change_mask".into(), false, n_rows - 1);
+
+    // For each group column, OR its change mask into the accumulator
+    for col_name in group_columns {
+        let series = df.column(col_name).map_err(|e| {
+            GgsqlError::InternalError(format!("Group column '{}' not found: {}", col_name, e))
+        })?;
+
+        // Compare each row with the previous row
+        // curr = series[1..n], prev = series[0..n-1]
+        let curr = series.slice(1, n_rows - 1);
+        let prev = series.slice(0, n_rows - 1);
+
+        // Get boolean mask where values differ
+        let not_equal = curr.not_equal(&prev).map_err(|e| {
+            GgsqlError::InternalError(format!("Failed to compare column '{}': {}", col_name, e))
+        })?;
+
+        // OR with accumulator (change if this column OR any previous column changed)
+        change_mask = &change_mask | &not_equal;
+    }
+
+    // Extract indices where mask is true (offset by 1 since we compared with previous)
+    let mut boundaries = vec![0];
+    for (idx, changed) in change_mask.into_iter().enumerate() {
+        if changed == Some(true) {
+            boundaries.push(idx + 1);
+        }
+    }
+
+    // Add final boundary (end of data)
+    boundaries.push(n_rows);
+
+    Ok(boundaries)
+}
+
+/// Check if an aesthetic varies within any group segment
+///
+/// Uses precomputed group boundaries to efficiently check if the aesthetic
+/// has multiple distinct values within any group segment.
+fn aesthetic_varies_within_groups(
+    df: &DataFrame,
+    aesthetic_col: &str,
+    group_boundaries: &[usize],
+) -> Result<bool> {
+    let series = df.column(aesthetic_col).map_err(|e| {
+        GgsqlError::InternalError(format!("Column '{}' not found: {}", aesthetic_col, e))
+    })?;
+
+    // Check each group segment
+    for window in group_boundaries.windows(2) {
+        let start = window[0];
+        let end = window[1];
+
+        if end - start < 2 {
+            continue; // Single-row groups can't vary
+        }
+
+        // Slice the series for this group and check uniqueness
+        let segment = series.slice(start as i64, (end - start) as usize);
+        let n_unique = segment.n_unique().map_err(|e| {
+            GgsqlError::InternalError(format!("Failed to count unique values: {}", e))
+        })?;
+
+        if n_unique > 1 {
+            return Ok(true);
+        }
+    }
+
+    Ok(false)
+}
+
+/// Metadata for segmented line rendering
+#[derive(Debug)]
+struct LineSegmentMetadata {
+    partition_columns: Vec<String>,
+}
+
 /// Renderer for line geom - preserves data order for correct line rendering
+///
+/// Automatically detects when material aesthetics (stroke, linetype) vary within
+/// partition groups and converts to segmented rendering using detail encoding.
 pub struct LineRenderer;
 
 impl GeomRenderer for LineRenderer {
+    fn prepare_data(
+        &self,
+        df: &DataFrame,
+        layer: &Layer,
+        _data_key: &str,
+        binned_columns: &HashMap<String, Vec<f64>>,
+    ) -> Result<PreparedData> {
+        // Identify material aesthetics that are column-mapped
+        let material_aesthetics = ["stroke", "linetype"];
+        let mut varying_aesthetics = Vec::new();
+
+        // Collect (aesthetic, column) pairs for material aesthetics that are mapped to columns
+        let mapped_material_aesthetics: Vec<(&str, String)> = material_aesthetics
+            .iter()
+            .filter_map(|aesthetic| {
+                if let Some(AestheticValue::Column { name: col, .. }) = layer.mappings.get(aesthetic) {
+                    Some((*aesthetic, col.clone()))
+                } else {
+                    None
+                }
+            })
+            .collect();
+
+        // Build list of partition columns EXCLUDING the material aesthetics we're checking
+        // (we need to check if they vary within the other partition groups)
+        let mut partition_columns: Vec<String> = layer
+            .partition_by
+            .iter()
+            .filter(|col| !mapped_material_aesthetics.iter().any(|(_, c)| c == *col))
+            .cloned()
+            .collect();
+
+        // Compute group boundaries once (without the material aesthetics)
+        let group_boundaries = find_group_boundaries(df, &partition_columns)?;
+
+        // Check each mapped material aesthetic for within-group variation
+        for (aesthetic, col) in &mapped_material_aesthetics {
+            // Check if this aesthetic varies within partition groups
+            let varies = aesthetic_varies_within_groups(df, col, &group_boundaries)?;
+            if varies {
+                varying_aesthetics.push(*aesthetic);
+            } else {
+                // If it doesn't vary within groups, treat it as a partition column
+                // (boundaries remain the same since the aesthetic changes only where partitions change)
+                partition_columns.push(col.clone());
+            }
+        }
+
+        // Return the data with segmentation metadata if needed
+        let values = if binned_columns.is_empty() {
+            dataframe_to_values(df)?
+        } else {
+            dataframe_to_values_with_bins(df, binned_columns)?
+        };
+
+        let needs_segmentation = !varying_aesthetics.is_empty();
+
+        if needs_segmentation {
+            // Use Composite with empty component name so dataset key = data_key (not data_key + suffix)
+            // This ensures the source filter works correctly with the unified dataset
+            Ok(PreparedData::Composite {
+                components: [("".to_string(), values)].iter().cloned().collect(),
+                metadata: Box::new(LineSegmentMetadata { partition_columns }),
+            })
+        } else {
+            Ok(PreparedData::Single { values })
+        }
+    }
+
     fn modify_encoding(
         &self,
         encoding: &mut Map<String, Value>,
@@ -351,6 +521,137 @@ impl GeomRenderer for LineRenderer {
             json!({"field": ROW_INDEX_COLUMN, "type": "quantitative"}),
         );
         Ok(())
+    }
+
+    fn finalize(
+        &self,
+        mut layer_spec: Value,
+        _layer: &Layer,
+        _data_key: &str,
+        prepared: &PreparedData,
+    ) -> Result<Vec<Value>> {
+        // Early return for standard line rendering
+        let PreparedData::Composite { metadata, .. } = prepared else {
+            return Ok(vec![layer_spec]);
+        };
+
+        // Extract partition columns from metadata
+        let metadata_any = metadata.as_ref() as &dyn Any;
+        let partition_columns = if let Some(meta) = metadata_any.downcast_ref::<LineSegmentMetadata>() {
+            &meta.partition_columns
+        } else {
+            return Err(GgsqlError::InternalError(
+                "Invalid metadata type for segmented line".to_string(),
+            ));
+        };
+
+        // Get position column names
+        let x_col = naming::aesthetic_column("pos1");
+        let y_col = naming::aesthetic_column("pos2");
+
+        // Segmented rendering using detail encoding:
+        // 1. Create segment IDs (row_index serves as segment ID)
+        // 2. Create next row's x/y values using window transform
+        // 3. Flatten to create 2 rows per segment (point_index: 0=start, 1=end)
+        // 4. Use calculate to pick current or next based on point_index
+        // 5. Add segment ID to detail encoding
+
+        // Preserve existing transforms (e.g., source filter)
+        let mut transforms = layer_spec
+            .get("transform")
+            .and_then(|t| t.as_array())
+            .cloned()
+            .unwrap_or_default();
+
+        // Step 1 & 2: Window transform to get next row's values
+        let window_ops = vec![
+            json!({
+                "op": "lead",
+                "field": x_col,
+                "as": format!("{}_next", x_col)
+            }),
+            json!({
+                "op": "lead",
+                "field": y_col,
+                "as": format!("{}_next", y_col)
+            }),
+        ];
+
+        let mut window_transform = json!({
+            "window": window_ops,
+            "sort": [{"field": ROW_INDEX_COLUMN}]
+        });
+
+        if !partition_columns.is_empty() {
+            window_transform["groupby"] = json!(partition_columns);
+        }
+
+        transforms.push(window_transform);
+
+        // Step 2b: Filter out last row in each group (no next point)
+        transforms.push(json!({
+            "filter": format!("datum.{}_next != null", x_col)
+        }));
+
+        // Step 3: Flatten to create 2 rows per segment
+        // Create a constant array [0, 1] to flatten
+        transforms.push(json!({
+            "calculate": "[0, 1]",
+            "as": "__segment_points__"
+        }));
+
+        transforms.push(json!({
+            "flatten": ["__segment_points__"],
+            "as": ["__point_index__"]
+        }));
+
+        // Step 4: Calculate actual x/y based on point_index
+        transforms.push(json!({
+            "calculate": format!("datum.__point_index__ == 0 ? datum.{} : datum.{}_next", x_col, x_col),
+            "as": format!("{}_final", x_col)
+        }));
+
+        transforms.push(json!({
+            "calculate": format!("datum.__point_index__ == 0 ? datum.{} : datum.{}_next", y_col, y_col),
+            "as": format!("{}_final", y_col)
+        }));
+
+        // Step 5: Create segment ID (use original row_index)
+        transforms.push(json!({
+            "calculate": format!("datum.{}", ROW_INDEX_COLUMN),
+            "as": "__segment_id__"
+        }));
+
+        layer_spec["transform"] = json!(transforms);
+        // Don't set layer_spec["data"] - use the unified top-level dataset
+        // The source filter transform will select the correct rows
+
+        // Update encodings to use final x/y and add segment_id to detail
+        if let Some(encoding_obj) = layer_spec.get_mut("encoding") {
+            if let Some(encoding_map) = encoding_obj.as_object_mut() {
+                // Update x encoding to use x_final
+                if let Some(x_enc) = encoding_map.get_mut("x") {
+                    if let Some(x_obj) = x_enc.as_object_mut() {
+                        x_obj.insert("field".to_string(), json!(format!("{}_final", x_col)));
+                    }
+                }
+
+                // Update y encoding to use y_final
+                if let Some(y_enc) = encoding_map.get_mut("y") {
+                    if let Some(y_obj) = y_enc.as_object_mut() {
+                        y_obj.insert("field".to_string(), json!(format!("{}_final", y_col)));
+                    }
+                }
+
+                // Add segment_id to detail encoding
+                encoding_map.insert("detail".to_string(), json!({
+                    "field": "__segment_id__",
+                    "type": "nominal"
+                }));
+            }
+        }
+
+        Ok(vec![layer_spec])
     }
 }
 

--- a/src/writer/vegalite/layer.rs
+++ b/src/writer/vegalite/layer.rs
@@ -420,16 +420,12 @@ fn aesthetic_varies_within_groups(
     Ok(false)
 }
 
-/// Metadata for segmented line rendering
-#[derive(Debug)]
-struct LineSegmentMetadata {
-    partition_columns: Vec<String>,
-}
-
 /// Renderer for line geom - preserves data order for correct line rendering
 ///
-/// Automatically detects when material aesthetics (stroke, linetype) vary within
-/// partition groups and converts to segmented rendering using detail encoding.
+/// Automatically detects when continuous material aesthetics (stroke, linewidth) vary
+/// within partition groups and converts to segmented rendering using detail encoding.
+/// Discrete material aesthetics (linetype, or discrete stroke) already define groups
+/// via partition_by and don't require special handling.
 pub struct LineRenderer;
 
 impl GeomRenderer for LineRenderer {
@@ -440,32 +436,14 @@ impl GeomRenderer for LineRenderer {
         _data_key: &str,
         binned_columns: &HashMap<String, Vec<f64>>,
     ) -> Result<PreparedData> {
-        // Identify material aesthetics that are column-mapped
-        let material_aesthetics = ["stroke", "linetype"];
-        let mut varying_aesthetics = Vec::new();
+        // Continuous material aesthetics that can trigger segmentation
+        // (linetype is always discrete and already handled via partition_by)
+        let material_aesthetics = ["stroke", "linewidth"];
 
-        // Collect (aesthetic, column) pairs for material aesthetics that are mapped to columns
-        let mapped_material_aesthetics: Vec<(&str, String)> = material_aesthetics
-            .iter()
-            .filter_map(|aesthetic| {
-                if let Some(AestheticValue::Column { name: col, .. }) = layer.mappings.get(aesthetic) {
-                    Some((*aesthetic, col.clone()))
-                } else {
-                    None
-                }
-            })
-            .collect();
+        // Start with existing partition_by (includes discrete material aesthetics already)
+        let partition_columns: Vec<String> = layer.partition_by.clone();
 
-        // Build list of partition columns EXCLUDING the material aesthetics we're checking
-        // (we need to check if they vary within the other partition groups)
-        let mut partition_columns: Vec<String> = layer
-            .partition_by
-            .iter()
-            .filter(|col| !mapped_material_aesthetics.iter().any(|(_, c)| c == *col))
-            .cloned()
-            .collect();
-
-        // Compute group boundaries once (without the material aesthetics)
+        // Compute group boundaries based on existing partitions
         let n_rows = df.height();
         let group_boundaries = if partition_columns.is_empty() || n_rows <= 1 {
             vec![0, n_rows]
@@ -475,16 +453,19 @@ impl GeomRenderer for LineRenderer {
             boundaries
         };
 
-        // Check each mapped material aesthetic for within-group variation
-        for (aesthetic, col) in &mapped_material_aesthetics {
-            // Check if this aesthetic varies within partition groups
-            let varies = aesthetic_varies_within_groups(df, col, &group_boundaries)?;
-            if varies {
-                varying_aesthetics.push(*aesthetic);
-            } else {
-                // If it doesn't vary within groups, treat it as a partition column
-                // (boundaries remain the same since the aesthetic changes only where partitions change)
-                partition_columns.push(col.clone());
+        // Check continuous material aesthetics (not in partition_by) for within-group variation
+        let mut varying_aesthetics: Vec<&str> = Vec::new();
+
+        for aesthetic in material_aesthetics {
+            if let Some(AestheticValue::Column { name: col, .. }) = layer.mappings.get(aesthetic) {
+                // Skip if already in partition_by (discrete, already defines groups)
+                if !layer.partition_by.contains(col) {
+                    // Continuous: check if varies within groups
+                    if aesthetic_varies_within_groups(df, col, &group_boundaries)? {
+                        varying_aesthetics.push(aesthetic);
+                        // Don't add to partition_columns - continuous values shouldn't partition
+                    }
+                }
             }
         }
 
@@ -502,7 +483,7 @@ impl GeomRenderer for LineRenderer {
             // This ensures the source filter works correctly with the unified dataset
             Ok(PreparedData::Composite {
                 components: [("".to_string(), values)].iter().cloned().collect(),
-                metadata: Box::new(LineSegmentMetadata { partition_columns }),
+                metadata: Box::new(()),
             })
         } else {
             Ok(PreparedData::Single { values })
@@ -527,23 +508,13 @@ impl GeomRenderer for LineRenderer {
     fn finalize(
         &self,
         mut layer_spec: Value,
-        _layer: &Layer,
+        layer: &Layer,
         _data_key: &str,
         prepared: &PreparedData,
     ) -> Result<Vec<Value>> {
         // Early return for standard line rendering
-        let PreparedData::Composite { metadata, .. } = prepared else {
+        let PreparedData::Composite { .. } = prepared else {
             return Ok(vec![layer_spec]);
-        };
-
-        // Extract partition columns from metadata
-        let metadata_any = metadata.as_ref() as &dyn Any;
-        let partition_columns = if let Some(meta) = metadata_any.downcast_ref::<LineSegmentMetadata>() {
-            &meta.partition_columns
-        } else {
-            return Err(GgsqlError::InternalError(
-                "Invalid metadata type for segmented line".to_string(),
-            ));
         };
 
         // Get position column names
@@ -583,8 +554,8 @@ impl GeomRenderer for LineRenderer {
             "sort": [{"field": ROW_INDEX_COLUMN}]
         });
 
-        if !partition_columns.is_empty() {
-            window_transform["groupby"] = json!(partition_columns);
+        if !layer.partition_by.is_empty() {
+            window_transform["groupby"] = json!(layer.partition_by);
         }
 
         transforms.push(window_transform);

--- a/src/writer/vegalite/mod.rs
+++ b/src/writer/vegalite/mod.rs
@@ -101,7 +101,7 @@ fn prepare_layer_data(
 
         // Add data to individual datasets based on prepared type
         match &prepared {
-            PreparedData::Single { values } => {
+            PreparedData::Single { values, .. } => {
                 individual_datasets.insert(data_key.clone(), json!(values));
             }
             PreparedData::Composite { components, .. } => {


### PR DESCRIPTION
This PR aims to fix #297.

Briefly:
* It swaps out the line mark for trail mark when `linewidth` varies within groups.
* It cuts lines up into segments when `stroke` or `opacity` vary within groups. This is mostly accomplished through vegalite transforms. In a more perfect world, these would all be interpolated between vertices and we'd all live happily ever after, but for now this'll do.

As a bonus, claude was hiding footguns all over the place so I disciplined it by having it write a dedicated child claude.md for the writer. It has been more well-behaved ever since.