### PR TITLE
Add Quarto option to generate documentation for LLMs

### DIFF
--- a/doc/_quarto.yml
+++ b/doc/_quarto.yml
@@ -8,6 +8,7 @@ website:
   description: |
     The home of ggsql. A declarative visualisation language build on top of SQL
     and the grammar of graphics.
+  llms-txt: true
   site-url: https://ggsql.org
   repo-url: https://github.com/posit-dev/ggsql
   issue-url: https://github.com/posit-dev/ggsql/issues


### PR DESCRIPTION
A small tweak to tell Quarto to output a `llms.txt` at root, linking to similar derived files throughout.