### PR TITLE
Fix live editor output

### DIFF
--- a/ggsql-wasm/demo/src/quarto/main.ts
+++ b/ggsql-wasm/demo/src/quarto/main.ts
@@ -100,9 +100,12 @@ function gatherCells(): CellInfo[] {
       const visCandidates = outputDiv.querySelectorAll<HTMLElement>(
         'div[id^="vis-"]'
       );
-      if (visCandidates.length > 0) {
-        visContainer = visCandidates[0];
-        visId = visContainer.id;
+      const match = Array.from(visCandidates).find((el) =>
+        /^vis-\d+$/.test(el.id)
+      );
+      if (match) {
+        visContainer = match;
+        visId = match.id;
       }
     }
 


### PR DESCRIPTION
When rendering live with the wasm build, match and replace elements like `vis-0000000000`, but not `vis-0000000000-outer`.