### PR TITLE
Add ggsql cell delimiters and code lens actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Added
 
+- Add cell delimiters and code lens actions to the Positron extension (#366)
 - ODBC is now turned on for the CLI as well (#344)
 
 ### Fixed

--- a/ggsql-vscode/package.json
+++ b/ggsql-vscode/package.json
@@ -61,6 +61,45 @@
         "category": "ggsql",
         "title": "Source Current File",
         "icon": "$(play)"
+      },
+      {
+        "command": "ggsql.runQuery",
+        "category": "ggsql",
+        "title": "Run Query"
+      },
+      {
+        "command": "ggsql.runCellsAbove",
+        "category": "ggsql",
+        "title": "Run Cells Above"
+      },
+      {
+        "command": "ggsql.runNextCell",
+        "category": "ggsql",
+        "title": "Run Next Cell"
+      },
+      {
+        "command": "ggsql.runCurrentAdvance",
+        "category": "ggsql",
+        "title": "Run Query and Advance"
+      }
+    ],
+    "keybindings": [
+      {
+        "command": "ggsql.runCurrentAdvance",
+        "key": "ctrl+enter",
+        "mac": "cmd+enter",
+        "when": "editorTextFocus && editorLangId == ggsql && ggsql.hasCodeCells && !findInputFocussed && !replaceInputFocussed"
+      },
+      {
+        "command": "ggsql.runCurrentAdvance",
+        "key": "shift+enter",
+        "when": "editorTextFocus && editorLangId == ggsql && ggsql.hasCodeCells && !findInputFocussed && !replaceInputFocussed"
+      },
+      {
+        "command": "ggsql.runQuery",
+        "key": "ctrl+shift+enter",
+        "mac": "cmd+shift+enter",
+        "when": "editorTextFocus && editorLangId == ggsql && ggsql.hasCodeCells && !findInputFocussed && !replaceInputFocussed"
       }
     ],
     "menus": {

--- a/ggsql-vscode/src/cellParser.ts
+++ b/ggsql-vscode/src/cellParser.ts
@@ -1,0 +1,69 @@
+import * as vscode from 'vscode';
+
+export interface Cell {
+	range: vscode.Range;
+	text: string;
+}
+
+const cellStartRegex = /^--\s*%%/;
+
+function isCellStart(line: string): boolean {
+	return cellStartRegex.test(line);
+}
+
+function extractCellText(cell: Cell, document: vscode.TextDocument): string {
+	const startLine = cell.range.start.line;
+	const endLine = cell.range.end.line;
+
+	// Skip the marker line if the cell starts with -- %%
+	const contentStart = isCellStart(document.lineAt(startLine).text)
+		? startLine + 1
+		: startLine;
+
+	if (contentStart > endLine) {
+		return '';
+	}
+
+	const contentRange = new vscode.Range(
+		new vscode.Position(contentStart, 0),
+		cell.range.end,
+	);
+	return document.getText(contentRange).trim();
+}
+
+export function parseCells(document: vscode.TextDocument): Cell[] {
+	const cells: Cell[] = [];
+	let currentStart: number | undefined;
+
+	for (let i = 0; i < document.lineCount; i++) {
+		if (isCellStart(document.lineAt(i).text)) {
+			if (currentStart !== undefined) {
+				const range = new vscode.Range(
+					new vscode.Position(currentStart, 0),
+					document.lineAt(i - 1).range.end,
+				);
+				const cell = { range, text: '' };
+				cell.text = extractCellText(cell, document);
+				if (cell.text.length > 0) {
+					cells.push(cell);
+				}
+			}
+			currentStart = i;
+		}
+	}
+
+	// Close the last cell (or treat entire document as one cell if no markers)
+	if (currentStart !== undefined) {
+		const range = new vscode.Range(
+			new vscode.Position(currentStart, 0),
+			document.lineAt(document.lineCount - 1).range.end,
+		);
+		const cell = { range, text: '' };
+		cell.text = extractCellText(cell, document);
+		if (cell.text.length > 0) {
+			cells.push(cell);
+		}
+	}
+
+	return cells;
+}

--- a/ggsql-vscode/src/codelens.ts
+++ b/ggsql-vscode/src/codelens.ts
@@ -1,0 +1,114 @@
+import * as vscode from 'vscode';
+import { parseCells, type Cell } from './cellParser';
+
+export class GgsqlCodeLensProvider implements vscode.CodeLensProvider {
+	provideCodeLenses(document: vscode.TextDocument): vscode.CodeLens[] {
+		const cells = parseCells(document);
+		const lenses: vscode.CodeLens[] = [];
+
+		for (let i = 0; i < cells.length; i++) {
+			const cell = cells[i];
+			const range = cell.range;
+
+			lenses.push(new vscode.CodeLens(range, {
+				title: '$(run) Run Query',
+				command: 'ggsql.runQuery',
+				arguments: [range.start.line],
+			}));
+
+			if (i > 0) {
+				lenses.push(new vscode.CodeLens(range, {
+					title: 'Run Above',
+					command: 'ggsql.runCellsAbove',
+					arguments: [range.start.line],
+				}));
+			}
+
+			if (i < cells.length - 1) {
+				lenses.push(new vscode.CodeLens(range, {
+					title: 'Run Next',
+					command: 'ggsql.runNextCell',
+					arguments: [range.start.line],
+				}));
+			}
+		}
+
+		return lenses;
+	}
+}
+
+function findCellAtLine(cells: Cell[], line: number): Cell | undefined {
+	const pos = new vscode.Position(line, 0);
+	return cells.find(cell => cell.range.contains(pos));
+}
+
+function findNextCell(cells: Cell[], line: number): Cell | undefined {
+	const pos = new vscode.Position(line, 0);
+	return cells.find(cell => cell.range.start.isAfter(pos));
+}
+
+export function registerCellCommands(
+	context: vscode.ExtensionContext,
+	executeCode: (code: string) => void,
+): void {
+	context.subscriptions.push(
+		vscode.commands.registerCommand('ggsql.runQuery', (line?: number) => {
+			const editor = vscode.window.activeTextEditor;
+			if (!editor || editor.document.languageId !== 'ggsql') { return; }
+			const cells = parseCells(editor.document);
+			const cell = line !== undefined
+				? findCellAtLine(cells, line)
+				: findCellAtLine(cells, editor.selection.active.line);
+			if (cell && cell.text.length > 0) {
+				executeCode(cell.text);
+			}
+		}),
+
+		vscode.commands.registerCommand('ggsql.runCurrentAdvance', (line?: number) => {
+			const editor = vscode.window.activeTextEditor;
+			if (!editor || editor.document.languageId !== 'ggsql') { return; }
+			const cells = parseCells(editor.document);
+			const targetLine = line ?? editor.selection.active.line;
+			const cell = findCellAtLine(cells, targetLine);
+			if (cell && cell.text.length > 0) {
+				executeCode(cell.text);
+			}
+			const next = findNextCell(cells, targetLine);
+			if (next) {
+				const goTo = Math.min(next.range.start.line + 1, next.range.end.line);
+				const pos = new vscode.Position(goTo, 0);
+				editor.selection = new vscode.Selection(pos, pos);
+				editor.revealRange(next.range);
+			}
+		}),
+
+		vscode.commands.registerCommand('ggsql.runCellsAbove', (line?: number) => {
+			const editor = vscode.window.activeTextEditor;
+			if (!editor || editor.document.languageId !== 'ggsql') { return; }
+			const cells = parseCells(editor.document);
+			const cursor = new vscode.Position(line ?? editor.selection.active.line, 0);
+			cells
+				.filter(cell => cell.range.start.isBefore(cursor) && !cell.range.contains(cursor))
+				.forEach(cell => {
+					if (cell.text.length > 0) {
+						executeCode(cell.text);
+					}
+				});
+		}),
+
+		vscode.commands.registerCommand('ggsql.runNextCell', (line?: number) => {
+			const editor = vscode.window.activeTextEditor;
+			if (!editor || editor.document.languageId !== 'ggsql') { return; }
+			const cells = parseCells(editor.document);
+			const targetLine = line ?? editor.selection.active.line;
+			const next = findNextCell(cells, targetLine);
+			if (next && next.text.length > 0) {
+				executeCode(next.text);
+				const goTo = Math.min(next.range.start.line + 1, next.range.end.line);
+				const pos = new vscode.Position(goTo, 0);
+				editor.selection = new vscode.Selection(pos, pos);
+				editor.revealRange(next.range);
+			}
+		}),
+	);
+}

--- a/ggsql-vscode/src/context.ts
+++ b/ggsql-vscode/src/context.ts
@@ -1,0 +1,27 @@
+import * as vscode from 'vscode';
+import { parseCells } from './cellParser';
+
+function setHasCodeCells(editor: vscode.TextEditor | undefined): void {
+	let value = false;
+	if (editor && editor.document.languageId === 'ggsql') {
+		value = parseCells(editor.document).length > 0;
+	}
+	vscode.commands.executeCommand('setContext', 'ggsql.hasCodeCells', value);
+}
+
+export function activateContextKeys(disposables: vscode.Disposable[]): void {
+	let activeEditor = vscode.window.activeTextEditor;
+	setHasCodeCells(activeEditor);
+
+	disposables.push(
+		vscode.window.onDidChangeActiveTextEditor(editor => {
+			activeEditor = editor;
+			setHasCodeCells(editor);
+		}),
+		vscode.workspace.onDidChangeTextDocument(event => {
+			if (activeEditor && event.document === activeEditor.document) {
+				setHasCodeCells(activeEditor);
+			}
+		}),
+	);
+}

--- a/ggsql-vscode/src/decorations.ts
+++ b/ggsql-vscode/src/decorations.ts
@@ -1,0 +1,66 @@
+import * as vscode from 'vscode';
+import { parseCells } from './cellParser';
+
+const activeCellBackground = new vscode.ThemeColor('notebook.selectedCellBackground');
+
+const backgroundDecoration = vscode.window.createTextEditorDecorationType({
+	backgroundColor: activeCellBackground,
+	isWholeLine: true,
+});
+
+export function activateDecorations(disposables: vscode.Disposable[]): void {
+	let timeout: NodeJS.Timeout | undefined;
+	let activeEditor = vscode.window.activeTextEditor;
+
+	function updateDecorations() {
+		if (!activeEditor || activeEditor.document.languageId !== 'ggsql') {
+			return;
+		}
+
+		const cells = parseCells(activeEditor.document);
+		const bgRanges: vscode.Range[] = [];
+
+		for (const cell of cells) {
+			if (cell.range.contains(activeEditor.selection.active)) {
+				bgRanges.push(cell.range);
+			}
+		}
+
+		activeEditor.setDecorations(backgroundDecoration, bgRanges);
+	}
+
+	function triggerUpdate(throttle = false) {
+		if (timeout) {
+			clearTimeout(timeout);
+			timeout = undefined;
+		}
+		if (throttle) {
+			timeout = setTimeout(updateDecorations, 250);
+		} else {
+			updateDecorations();
+		}
+	}
+
+	if (activeEditor) {
+		triggerUpdate();
+	}
+
+	disposables.push(
+		vscode.window.onDidChangeActiveTextEditor(editor => {
+			activeEditor = editor;
+			if (editor) {
+				triggerUpdate();
+			}
+		}),
+		vscode.workspace.onDidChangeTextDocument(event => {
+			if (activeEditor && event.document === activeEditor.document) {
+				triggerUpdate(true);
+			}
+		}),
+		vscode.window.onDidChangeTextEditorSelection(event => {
+			if (activeEditor && event.textEditor === activeEditor) {
+				triggerUpdate();
+			}
+		}),
+	);
+}

--- a/ggsql-vscode/src/extension.ts
+++ b/ggsql-vscode/src/extension.ts
@@ -9,6 +9,10 @@ import * as vscode from 'vscode';
 import { tryAcquirePositronApi } from '@posit-dev/positron';
 import { GgsqlRuntimeManager } from './manager';
 import { createConnectionDrivers } from './connections';
+import { GgsqlCodeLensProvider, registerCellCommands } from './codelens';
+import { activateDecorations } from './decorations';
+import { activateContextKeys } from './context';
+import { parseCells } from './cellParser';
 
 // Output channel for logging
 const outputChannel = vscode.window.createOutputChannel('ggsql');
@@ -60,13 +64,33 @@ export function activate(context: vscode.ExtensionContext): void {
             if (!editor || editor.document.languageId !== 'ggsql') {
                 return;
             }
-            const code = editor.document.getText();
-            if (code.trim().length === 0) {
-                return;
+            const cells = parseCells(editor.document);
+            if (cells.length > 0) {
+                for (const cell of cells) {
+                    if (cell.text.length > 0) {
+                        positronApi.runtime.executeCode('ggsql', cell.text, false, true);
+                    }
+                }
+            } else {
+                const code = editor.document.getText();
+                if (code.trim().length === 0) {
+                    return;
+                }
+                positronApi.runtime.executeCode('ggsql', code, true);
             }
-            positronApi.runtime.executeCode('ggsql', code, true);
         })
     );
+
+    // Register code lens provider and cell commands
+    context.subscriptions.push(
+        vscode.languages.registerCodeLensProvider('ggsql', new GgsqlCodeLensProvider()),
+    );
+    registerCellCommands(context, (code) => {
+        positronApi.runtime.executeCode('ggsql', code, false, true);
+    });
+
+    activateDecorations(context.subscriptions);
+    activateContextKeys(context.subscriptions);
 }
 
 /**


### PR DESCRIPTION
* Adds `-- %%`  as a cell delimiter for ggsql code in Positron.
* Code lens actions are added to run the current, previous, and next cells in the console.
* Ctrl/Cmd-Enter now executes the current cell in entirety, then moves onto the next cell, if cell delimiters are used.

Currently users must manually add cell delimiters, but in the future we can find and separate entire statements using an LSP server.

https://github.com/user-attachments/assets/ba8db71b-19ef-4397-b114-ad74badbf283

Closes #362.
