### PR TITLE
Setting named shapes to SVG paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 - Rendering of inline plots in Positron had a bad interaction with how we
 handled auto-resizing in the plot pane. We now have a per-output-location path
 in the Jupyter kernel (#360)
+- Passing the shape aesthetic via `SETTING` now correctly translates named 
+shapes (#368)
 
 ### Changed
 

--- a/src/writer/vegalite/encoding.rs
+++ b/src/writer/vegalite/encoding.rs
@@ -1218,4 +1218,24 @@ mod tests {
             "None mapping should suppress label (empty string), got: {expr}"
         );
     }
+
+    #[test]
+    fn test_literal_shape_converts_to_svg_path() {
+        let lit = ParameterValue::String("square".to_string());
+        let result = build_literal_encoding("shape", &lit).unwrap();
+        let val = &result["value"];
+        assert!(val.is_string(), "expected SVG path string, got: {val}");
+        let path = val.as_str().unwrap();
+        assert!(
+            path.starts_with('M') && path.contains('Z'),
+            "expected SVG path with M and Z commands, got: {path}"
+        );
+    }
+
+    #[test]
+    fn test_literal_shape_unknown_passes_through() {
+        let lit = ParameterValue::String("nonexistent".to_string());
+        let result = build_literal_encoding("shape", &lit).unwrap();
+        assert_eq!(result, json!({"value": "nonexistent"}));
+    }
 }

--- a/src/writer/vegalite/encoding.rs
+++ b/src/writer/vegalite/encoding.rs
@@ -955,12 +955,14 @@ fn build_column_encoding(
 /// Build encoding for a literal aesthetic value
 fn build_literal_encoding(aesthetic: &str, lit: &ParameterValue) -> Result<Value> {
     let val = match lit {
-        ParameterValue::String(s) => match aesthetic {
-            "linetype" => linetype_to_stroke_dash(s)
-                .map(|arr| json!(arr))
-                .unwrap_or_else(|| json!(s)),
-            _ => json!(s),
-        },
+        ParameterValue::String(s) => {
+            let converted = match aesthetic {
+                "linetype" => linetype_to_stroke_dash(s).map(|arr| json!(arr)),
+                "shape" => shape_to_svg_path(s).map(|arr| json!(arr)),
+                _ => None,
+            };
+            converted.unwrap_or_else(|| json!(s))
+        }
         ParameterValue::Number(n) => {
             match aesthetic {
                 // Size: radius (points) → area (pixels²)


### PR DESCRIPTION
This PR aims to fix #368.

We're just using the pre-existing `shape_to_svg_path` to also translate literal `shape` aesthetics.