### PR TITLE
Fix boxplot median line dropped by OOB null-filtering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and writer errors now report user-facing aesthetic names (`x`, `y`, `panel`,
 based on the active coordinate system and facet layout (#388).
 - Fixed opacity calculation in point layers with Vega-Lite (#393)
 - Fixed an issue with case-sensitive column references in mappings (#374)
+- Fixed an issue with OOB null-filtering, leading to missing median lines in boxplots (#394)
 
 ### Changed
 

--- a/src/execute/scale.rs
+++ b/src/execute/scale.rs
@@ -1123,6 +1123,8 @@ pub fn apply_scale_oob(spec: &Plot, data_map: &mut HashMap<String, DataFrame>) -
 
     // Second pass: filter out NULL rows for scales with explicit input ranges
     // This handles NULLs created by both pre-stat SQL censoring and post-stat OOB censor
+    // Only filter on the primary aesthetic column, not suffixed variants (min/max/end),
+    // because those can be legitimately NULL (e.g., boxplot median rows have NULL pos2end).
     for scale in &spec.scales {
         // Only filter if explicit input range AND NULL is not in the range
         let should_filter_nulls = scale.explicit_input_range
@@ -1135,18 +1137,20 @@ pub fn apply_scale_oob(spec: &Plot, data_map: &mut HashMap<String, DataFrame>) -
             continue;
         }
 
-        let column_sources = find_columns_for_aesthetic_with_sources(
-            &spec.layers,
-            &scale.aesthetic,
-            data_map,
-            &aesthetic_ctx,
-        );
-
-        for (data_key, col_name) in column_sources {
-            if let Some(df) = data_map.get(&data_key) {
-                if df.column(&col_name).is_ok() {
-                    let filtered = filter_null_rows(df, &col_name)?;
-                    data_map.insert(data_key, filtered);
+        let primary_aesthetic = &scale.aesthetic;
+        for (i, layer) in spec.layers.iter().enumerate() {
+            let layer_key = naming::layer_key(i);
+            if !data_map.contains_key(&layer_key) {
+                continue;
+            }
+            if let Some(AestheticValue::Column { name, .. }) = layer.mappings.get(primary_aesthetic)
+            {
+                let col_name = name.clone();
+                if let Some(df) = data_map.get(&layer_key) {
+                    if df.column(&col_name).is_ok() {
+                        let filtered = filter_null_rows(df, &col_name)?;
+                        data_map.insert(layer_key, filtered);
+                    }
                 }
             }
         }

--- a/src/execute/scale.rs
+++ b/src/execute/scale.rs
@@ -1121,10 +1121,10 @@ pub fn apply_scale_oob(spec: &Plot, data_map: &mut HashMap<String, DataFrame>) -
         }
     }
 
-    // Second pass: filter out NULL rows for scales with explicit input ranges
-    // This handles NULLs created by both pre-stat SQL censoring and post-stat OOB censor
-    // Only filter on the primary aesthetic column, not suffixed variants (min/max/end),
-    // because those can be legitimately NULL (e.g., boxplot median rows have NULL pos2end).
+    // Second pass: filter out NULL rows for scales with explicit input ranges.
+    // This handles NULLs created by both pre-stat SQL censoring and post-stat OOB censor.
+    // Only filter on aesthetics that are required by the layer's geom — optional/delayed
+    // aesthetics (e.g. boxplot's pos2end) can be legitimately NULL.
     for scale in &spec.scales {
         // Only filter if explicit input range AND NULL is not in the range
         let should_filter_nulls = scale.explicit_input_range
@@ -1137,19 +1137,30 @@ pub fn apply_scale_oob(spec: &Plot, data_map: &mut HashMap<String, DataFrame>) -
             continue;
         }
 
-        let primary_aesthetic = &scale.aesthetic;
+        let family = aesthetic_ctx
+            .internal_position_family(&scale.aesthetic)
+            .map(|f| f.to_vec())
+            .unwrap_or_else(|| vec![scale.aesthetic.clone()]);
+
         for (i, layer) in spec.layers.iter().enumerate() {
             let layer_key = naming::layer_key(i);
             if !data_map.contains_key(&layer_key) {
                 continue;
             }
-            if let Some(AestheticValue::Column { name, .. }) = layer.mappings.get(primary_aesthetic)
-            {
-                let col_name = name.clone();
-                if let Some(df) = data_map.get(&layer_key) {
-                    if df.column(&col_name).is_ok() {
-                        let filtered = filter_null_rows(df, &col_name)?;
-                        data_map.insert(layer_key, filtered);
+            let geom_aesthetics = layer.geom.aesthetics();
+            for aes_name in &family {
+                if !geom_aesthetics.is_required(aes_name) {
+                    continue;
+                }
+                if let Some(AestheticValue::Column { name, .. }) =
+                    layer.mappings.get(aes_name.as_str())
+                {
+                    let col_name = name.clone();
+                    if let Some(df) = data_map.get(&layer_key) {
+                        if df.column(&col_name).is_ok() {
+                            let filtered = filter_null_rows(df, &col_name)?;
+                            data_map.insert(layer_key.clone(), filtered);
+                        }
                     }
                 }
             }


### PR DESCRIPTION
OOB null-filtering for scales with explicit ranges (`SCALE y FROM ...`) was checking all position family columns (`pos2`, `pos2end`, etc.), dropping rows where secondary columns were legitimately `NULL`, like boxplot median rows where       
  `pos2end` is always `NULL`.

This PR restricts null-filtering to only the primary aesthetic column.

@teunbrand You have worked on the boxplot system way more than I have, does this Claude-originating change seem reasonable to you?