### PR TITLE
Fix data-panel misassignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Fixed bug where panel axes were unintentionally anchored to zero when using 
   `FACET ... SETTING free => 'x'/'y'` (#410).
+- Fixed bug where faceted data were matched to the incorrect panels (#409)
 
 ## 0.3.1 - 2026-04-30
 

--- a/src/writer/vegalite/mod.rs
+++ b/src/writer/vegalite/mod.rs
@@ -421,71 +421,15 @@ fn apply_faceting(
 
     match &facet.layout {
         FacetLayout::Wrap { variables: _ } => {
-            // Use internal aesthetic column name (facet1)
-            let aes_col = naming::aesthetic_column("facet1");
-
-            // Look up scale for internal "facet1" aesthetic
-            let scale = scales.iter().find(|s| s.aesthetic == "facet1");
-
-            // Build facet field definition with proper binned support
-            let mut facet_def = build_facet_field_def(facet_df, &aes_col, scale);
-
-            // Apply facet ordering — resolve the value→index mapping, then rewrite
-            // data column values to integers for correct panel order
-            let index_map = resolve_facet_ordering(scale);
-            apply_facet_ordering(vl_spec, &aes_col, &index_map);
-
-            // Use scale label_mapping for custom labels
-            let label_mapping = scale.and_then(|s| s.label_mapping.as_ref());
-
-            // Apply label renaming via header.labelExpr
-            apply_facet_label_renaming(&mut facet_def, label_mapping, scale, &index_map);
-
-            // For binned facets with reverse, set sort: "descending"
-            apply_binned_facet_reverse(&mut facet_def, scale);
-
+            let facet_def = apply_facet_aesthetic(vl_spec, facet_df, scales, "facet1");
             vl_spec["facet"] = facet_def;
-
-            // Move layer + width/height into inner spec (FacetSpec disallows
-            // top-level width/height in VL v6)
-            let mut spec_inner = json!({});
-            if let Some(layer) = vl_spec.get("layer") {
-                spec_inner["layer"] = layer.clone();
-            }
-            if let Some(w) = vl_spec.get("width").cloned() {
-                spec_inner["width"] = w;
-            }
-            if let Some(h) = vl_spec.get("height").cloned() {
-                spec_inner["height"] = h;
-            }
-
-            vl_spec["spec"] = spec_inner;
-            let obj = vl_spec.as_object_mut().unwrap();
-            obj.remove("layer");
-            obj.remove("width");
-            obj.remove("height");
-
-            apply_facet_scale_resolution(vl_spec, &facet.properties, coord_kind);
-            apply_facet_properties(vl_spec, &facet.properties, true);
         }
         FacetLayout::Grid { row: _, column: _ } => {
             let mut facet_spec = serde_json::Map::new();
+
             let row_aes_col = naming::aesthetic_column("facet1");
             if facet_df.column(&row_aes_col).is_ok() {
-                let row_scale = scales.iter().find(|s| s.aesthetic == "facet1");
-                let mut row_def = build_facet_field_def(facet_df, &row_aes_col, row_scale);
-
-                let row_index_map = resolve_facet_ordering(row_scale);
-                apply_facet_ordering(vl_spec, &row_aes_col, &row_index_map);
-                let row_label_mapping = row_scale.and_then(|s| s.label_mapping.as_ref());
-                apply_facet_label_renaming(
-                    &mut row_def,
-                    row_label_mapping,
-                    row_scale,
-                    &row_index_map,
-                );
-                apply_binned_facet_reverse(&mut row_def, row_scale);
-
+                let row_def = apply_facet_aesthetic(vl_spec, facet_df, scales, "facet1");
                 facet_spec.insert("row".to_string(), row_def);
             }
 
@@ -493,47 +437,62 @@ fn apply_faceting(
             // Vega-Lite requires "column" key in the facet object
             let col_aes_col = naming::aesthetic_column("facet2");
             if facet_df.column(&col_aes_col).is_ok() {
-                let col_scale = scales.iter().find(|s| s.aesthetic == "facet2");
-                let mut col_def = build_facet_field_def(facet_df, &col_aes_col, col_scale);
-
-                let col_index_map = resolve_facet_ordering(col_scale);
-                apply_facet_ordering(vl_spec, &col_aes_col, &col_index_map);
-                let col_label_mapping = col_scale.and_then(|s| s.label_mapping.as_ref());
-                apply_facet_label_renaming(
-                    &mut col_def,
-                    col_label_mapping,
-                    col_scale,
-                    &col_index_map,
-                );
-                apply_binned_facet_reverse(&mut col_def, col_scale);
-
+                let col_def = apply_facet_aesthetic(vl_spec, facet_df, scales, "facet2");
                 facet_spec.insert("column".to_string(), col_def);
             }
 
             vl_spec["facet"] = Value::Object(facet_spec);
-
-            // Move layer + width/height into inner spec (same as wrap above)
-            let mut spec_inner = json!({});
-            if let Some(layer) = vl_spec.get("layer") {
-                spec_inner["layer"] = layer.clone();
-            }
-            if let Some(w) = vl_spec.get("width").cloned() {
-                spec_inner["width"] = w;
-            }
-            if let Some(h) = vl_spec.get("height").cloned() {
-                spec_inner["height"] = h;
-            }
-
-            vl_spec["spec"] = spec_inner;
-            let obj = vl_spec.as_object_mut().unwrap();
-            obj.remove("layer");
-            obj.remove("width");
-            obj.remove("height");
-
-            apply_facet_scale_resolution(vl_spec, &facet.properties, coord_kind);
-            apply_facet_properties(vl_spec, &facet.properties, false);
         }
     }
+
+    // Move layer + width/height into inner spec (FacetSpec disallows
+    // top-level layer/width/height in Vega-Lite v6)
+    let mut spec_inner = json!({});
+    if let Some(layer) = vl_spec.get("layer") {
+        spec_inner["layer"] = layer.clone();
+    }
+    if let Some(w) = vl_spec.get("width").cloned() {
+        spec_inner["width"] = w;
+    }
+    if let Some(h) = vl_spec.get("height").cloned() {
+        spec_inner["height"] = h;
+    }
+
+    vl_spec["spec"] = spec_inner;
+    let obj = vl_spec.as_object_mut().unwrap();
+    obj.remove("layer");
+    obj.remove("width");
+    obj.remove("height");
+
+    apply_facet_scale_resolution(vl_spec, &facet.properties, coord_kind);
+    apply_facet_properties(vl_spec, &facet.properties, facet.is_wrap());
+}
+
+/// Build a fully resolved facet field definition for a single facet aesthetic.
+///
+/// Combines all per-field steps: build the base definition, resolve and apply
+/// panel ordering (rewriting data values to integers), apply label renaming
+/// via header.labelExpr, and handle binned reverse sort.
+fn apply_facet_aesthetic(
+    vl_spec: &mut Value,
+    facet_df: &DataFrame,
+    scales: &[Scale],
+    aesthetic: &str,
+) -> Value {
+    let aes_col = naming::aesthetic_column(aesthetic);
+    let scale = scales.iter().find(|s| s.aesthetic == aesthetic);
+
+    let mut facet_def = build_facet_field_def(facet_df, &aes_col, scale);
+
+    let index_map = resolve_facet_ordering(scale);
+    apply_facet_ordering(vl_spec, &aes_col, &index_map);
+
+    let label_mapping = scale.and_then(|s| s.label_mapping.as_ref());
+    apply_facet_label_renaming(&mut facet_def, label_mapping, scale, &index_map);
+
+    apply_binned_facet_reverse(&mut facet_def, scale);
+
+    facet_def
 }
 
 /// Build a facet field definition with proper type.

--- a/src/writer/vegalite/mod.rs
+++ b/src/writer/vegalite/mod.rs
@@ -430,14 +430,19 @@ fn apply_faceting(
             // Build facet field definition with proper binned support
             let mut facet_def = build_facet_field_def(facet_df, &aes_col, scale);
 
+            // Apply facet ordering — resolve the value→index mapping, then rewrite
+            // data column values to integers for correct panel order
+            let index_map = resolve_facet_ordering(scale);
+            apply_facet_ordering(vl_spec, &aes_col, &index_map);
+
             // Use scale label_mapping for custom labels
             let label_mapping = scale.and_then(|s| s.label_mapping.as_ref());
 
             // Apply label renaming via header.labelExpr
-            apply_facet_label_renaming(&mut facet_def, label_mapping, scale);
+            apply_facet_label_renaming(&mut facet_def, label_mapping, scale, &index_map);
 
-            // Apply facet ordering from breaks/reverse
-            apply_facet_ordering(&mut facet_def, scale);
+            // For binned facets with reverse, set sort: "descending"
+            apply_binned_facet_reverse(&mut facet_def, scale);
 
             vl_spec["facet"] = facet_def;
 
@@ -470,9 +475,16 @@ fn apply_faceting(
                 let row_scale = scales.iter().find(|s| s.aesthetic == "facet1");
                 let mut row_def = build_facet_field_def(facet_df, &row_aes_col, row_scale);
 
+                let row_index_map = resolve_facet_ordering(row_scale);
+                apply_facet_ordering(vl_spec, &row_aes_col, &row_index_map);
                 let row_label_mapping = row_scale.and_then(|s| s.label_mapping.as_ref());
-                apply_facet_label_renaming(&mut row_def, row_label_mapping, row_scale);
-                apply_facet_ordering(&mut row_def, row_scale);
+                apply_facet_label_renaming(
+                    &mut row_def,
+                    row_label_mapping,
+                    row_scale,
+                    &row_index_map,
+                );
+                apply_binned_facet_reverse(&mut row_def, row_scale);
 
                 facet_spec.insert("row".to_string(), row_def);
             }
@@ -484,9 +496,16 @@ fn apply_faceting(
                 let col_scale = scales.iter().find(|s| s.aesthetic == "facet2");
                 let mut col_def = build_facet_field_def(facet_df, &col_aes_col, col_scale);
 
+                let col_index_map = resolve_facet_ordering(col_scale);
+                apply_facet_ordering(vl_spec, &col_aes_col, &col_index_map);
                 let col_label_mapping = col_scale.and_then(|s| s.label_mapping.as_ref());
-                apply_facet_label_renaming(&mut col_def, col_label_mapping, col_scale);
-                apply_facet_ordering(&mut col_def, col_scale);
+                apply_facet_label_renaming(
+                    &mut col_def,
+                    col_label_mapping,
+                    col_scale,
+                    &col_index_map,
+                );
+                apply_binned_facet_reverse(&mut col_def, col_scale);
 
                 facet_spec.insert("column".to_string(), col_def);
             }
@@ -548,13 +567,17 @@ fn build_facet_field_def(df: &DataFrame, col: &str, scale: Option<&Scale>) -> Va
     field_def
 }
 
-/// Apply facet ordering via Vega-Lite's sort property.
+/// Resolve facet ordering into a value → index mapping.
 ///
-/// For discrete facets: uses input_range (FROM clause) or breaks array order
-/// For binned facets: uses "descending" sort if reversed
-fn apply_facet_ordering(facet_def: &mut Value, scale: Option<&Scale>) {
+/// For discrete facets: uses input_range (FROM clause) or breaks array order.
+/// For binned facets: returns empty (bin midpoints already sort correctly).
+///
+/// The returned mapping is consumed by `apply_facet_ordering` (to rewrite the
+/// data column to integers) and `apply_facet_label_renaming` (to build a
+/// `header.labelExpr` that restores the display labels).
+fn resolve_facet_ordering(scale: Option<&Scale>) -> Vec<(Value, usize)> {
     let Some(scale) = scale else {
-        return;
+        return Vec::new();
     };
 
     let is_reversed = matches!(
@@ -569,33 +592,93 @@ fn apply_facet_ordering(facet_def: &mut Value, scale: Option<&Scale>) {
         .unwrap_or(false);
 
     if is_binned {
-        // For binned facets: use "descending" sort if reversed
-        if is_reversed {
-            facet_def["sort"] = json!("descending");
-        }
-        // Default is ascending, no need to specify
+        // Binned facets use numeric midpoints that sort naturally — no index
+        // rewriting needed. Reversed binned facets are handled separately via
+        // apply_binned_facet_reverse on the facet definition.
+        return Vec::new();
+    }
+
+    // For discrete facets: use input_range (FROM clause) if present,
+    // otherwise fall back to breaks property
+    let order_values: Vec<ArrayElement> = if let Some(ref input_range) = scale.input_range {
+        // Use explicit input_range from FROM clause
+        input_range.clone()
+    } else if let Some(ParameterValue::Array(arr)) = scale.properties.get("breaks") {
+        // Fall back to breaks if present
+        arr.clone()
     } else {
-        // For discrete facets: use input_range (FROM clause) if present,
-        // otherwise fall back to breaks property
-        let order_values: Vec<ArrayElement> = if let Some(ref input_range) = scale.input_range {
-            // Use explicit input_range from FROM clause
-            input_range.clone()
-        } else if let Some(ParameterValue::Array(arr)) = scale.properties.get("breaks") {
-            // Fall back to breaks if present
-            arr.clone()
-        } else {
-            return;
-        };
+        return Vec::new();
+    };
 
-        // Convert to JSON values, preserving null
-        let mut sort_values: Vec<Value> = order_values.iter().map(|e| e.to_json()).collect();
+    // Convert to JSON values, preserving null
+    let mut sort_values: Vec<Value> = order_values.iter().map(|e| e.to_json()).collect();
 
-        // Apply reverse if specified
-        if is_reversed {
-            sort_values.reverse();
+    // Apply reverse if specified
+    if is_reversed {
+        sort_values.reverse();
+    }
+
+    sort_values
+        .iter()
+        .enumerate()
+        .map(|(i, v)| (v.clone(), i))
+        .collect()
+}
+
+/// For binned facets with `reverse => true`, set `sort: "descending"` on the
+/// facet definition. Discrete facets handle reversal through `resolve_facet_ordering`
+/// (which reverses the index map), so this only applies to binned facets.
+fn apply_binned_facet_reverse(facet_def: &mut Value, scale: Option<&Scale>) {
+    let Some(scale) = scale else { return };
+
+    let is_binned = scale
+        .scale_type
+        .as_ref()
+        .map(|st| st.scale_type_kind() == ScaleTypeKind::Binned)
+        .unwrap_or(false);
+
+    if !is_binned {
+        return;
+    }
+
+    if matches!(
+        scale.properties.get("reverse"),
+        Some(ParameterValue::Boolean(true))
+    ) {
+        facet_def["sort"] = json!("descending");
+    }
+}
+
+/// Rewrite facet column values in `vl_spec.data.values` to integer sort indices.
+///
+/// Uses the mapping produced by `resolve_facet_ordering`. Values not present in
+/// the mapping are assigned an index past the end (so they sort last).
+///
+/// Using integers instead of a literal `sort` array works around a Vega-Lite bug
+/// where explicit sort arrays on facet definitions cause data-panel misalignment
+/// (https://github.com/vega/vega-lite/issues/8675).
+fn apply_facet_ordering(vl_spec: &mut Value, facet_col: &str, index_map: &[(Value, usize)]) {
+    if index_map.is_empty() {
+        return;
+    }
+
+    if let Some(data) = vl_spec
+        .get_mut("data")
+        .and_then(|d| d.get_mut("values"))
+        .and_then(|v| v.as_array_mut())
+    {
+        let fallback = index_map.len();
+        for row in data.iter_mut() {
+            if let Some(obj) = row.as_object_mut() {
+                let orig = obj.get(facet_col).cloned().unwrap_or(Value::Null);
+                let idx = index_map
+                    .iter()
+                    .find(|(v, _)| *v == orig)
+                    .map(|(_, i)| *i)
+                    .unwrap_or(fallback);
+                obj.insert(facet_col.to_string(), json!(idx));
+            }
         }
-
-        facet_def["sort"] = json!(sort_values);
     }
 }
 
@@ -673,7 +756,10 @@ fn apply_facet_scale_resolution(
 /// Apply label renaming to a facet definition via header.labelExpr
 ///
 /// Uses Vega expression to transform facet labels:
-/// - For discrete facets: 'A' => 'Alpha' becomes datum.value == 'A' ? 'Alpha' : ...
+/// - For discrete facets (non-empty `index_map`): the facet column has been
+///   converted to integer sort indices by `apply_facet_ordering`. The labelExpr
+///   maps those integers back to display labels, applying user renaming
+///   (RENAMING clause) when present.
 /// - For binned facets: uses build_symbol_legend_label_mapping for range-style labels
 /// - NULL values suppress labels (maps to empty string)
 ///
@@ -683,10 +769,19 @@ fn apply_facet_label_renaming(
     facet_def: &mut Value,
     label_mapping: Option<&HashMap<String, Option<String>>>,
     scale: Option<&Scale>,
+    index_map: &[(Value, usize)],
 ) {
+    if !index_map.is_empty() {
+        // Facet column was converted to integers — build labelExpr mapping
+        // index → display label (applying user renaming when present).
+        let label_expr = build_indexed_facet_label_expr(index_map, label_mapping);
+        facet_def["header"] = json!({ "labelExpr": label_expr });
+        return;
+    }
+
+    // No index map: original (non-ordered or binned) path.
     // Only apply if there's a label mapping
     let has_mapping = label_mapping.is_some_and(|m| !m.is_empty());
-
     if !has_mapping {
         return;
     }
@@ -706,9 +801,7 @@ fn apply_facet_label_renaming(
     };
 
     // Add to facet definition
-    facet_def["header"] = json!({
-        "labelExpr": label_expr
-    });
+    facet_def["header"] = json!({ "labelExpr": label_expr });
 }
 
 /// Build labelExpr for binned facet values.
@@ -880,6 +973,47 @@ fn calculate_midpoint_string(
         }
         _ => None,
     }
+}
+
+/// Build labelExpr for integer-indexed facet values.
+///
+/// The `index_map` contains (original_value, sort_index) pairs produced by
+/// `apply_facet_ordering`. Each entry becomes a ternary branch mapping the
+/// integer back to a display label. When `label_mapping` provides a rename
+/// for an original value, the renamed label is used.
+fn build_indexed_facet_label_expr(
+    index_map: &[(Value, usize)],
+    label_mapping: Option<&HashMap<String, Option<String>>>,
+) -> String {
+    let mut expr_parts: Vec<String> = Vec::new();
+
+    for (orig_value, idx) in index_map {
+        let condition = format!("datum.value == {}", idx);
+
+        // Determine the display label: check user renaming first, else use original
+        let key = match orig_value {
+            Value::Null => "null".to_string(),
+            Value::String(s) => s.clone(),
+            other => other.to_string(),
+        };
+
+        let label = label_mapping
+            .and_then(|m| m.get(&key))
+            .cloned()
+            .unwrap_or(Some(key));
+
+        let result = match label {
+            Some(l) => format!("'{}'", escape_vega_string(&l)),
+            None => "''".to_string(),
+        };
+        expr_parts.push(format!("{} ? {}", condition, result));
+    }
+
+    let mut expr = "datum.value".to_string();
+    for part in expr_parts.into_iter().rev() {
+        expr = format!("{} : {}", part, expr);
+    }
+    expr
 }
 
 /// Build labelExpr for discrete facet values.
@@ -2269,10 +2403,8 @@ mod tests {
 
     #[test]
     fn test_facet_ordering_uses_input_range() {
-        // Test that apply_facet_ordering uses input_range (FROM clause) for discrete scales
+        // Test that resolve_facet_ordering uses input_range (FROM clause) for discrete scales
         use crate::plot::scale::Scale;
-
-        let mut facet_def = json!({"field": "__ggsql_aes_facet1__", "type": "nominal"});
 
         // Create a scale with input_range (simulating SCALE panel FROM ['A', 'B', 'C'])
         let mut scale = Scale::new("facet1");
@@ -2282,23 +2414,20 @@ mod tests {
             ArrayElement::String("C".to_string()),
         ]);
 
-        apply_facet_ordering(&mut facet_def, Some(&scale));
+        let index_map = resolve_facet_ordering(Some(&scale));
 
-        // Verify sort order matches input_range
-        assert_eq!(
-            facet_def["sort"],
-            json!(["A", "B", "C"]),
-            "Facet sort should use input_range order"
-        );
+        // Verify index map matches input_range order
+        assert_eq!(index_map.len(), 3);
+        assert_eq!(index_map[0], (json!("A"), 0));
+        assert_eq!(index_map[1], (json!("B"), 1));
+        assert_eq!(index_map[2], (json!("C"), 2));
     }
 
     #[test]
     fn test_facet_ordering_with_null_in_input_range() {
-        // Test that apply_facet_ordering preserves null values in input_range
+        // Test that resolve_facet_ordering preserves null values in input_range
         // This is the fix for the bug where null panels appear first
         use crate::plot::scale::Scale;
-
-        let mut facet_def = json!({"field": "__ggsql_aes_facet1__", "type": "nominal"});
 
         // Create a scale with input_range including null at the end
         // (simulating SCALE panel FROM ['Adelie', 'Gentoo', null])
@@ -2309,22 +2438,18 @@ mod tests {
             ArrayElement::Null,
         ]);
 
-        apply_facet_ordering(&mut facet_def, Some(&scale));
+        let index_map = resolve_facet_ordering(Some(&scale));
 
-        // Verify sort order preserves null at the end
-        assert_eq!(
-            facet_def["sort"],
-            json!(["Adelie", "Gentoo", null]),
-            "Facet sort should preserve null position from input_range"
-        );
+        // Verify null is at index 2 (last)
+        assert_eq!(index_map[0], (json!("Adelie"), 0));
+        assert_eq!(index_map[1], (json!("Gentoo"), 1));
+        assert_eq!(index_map[2], (Value::Null, 2));
     }
 
     #[test]
     fn test_facet_ordering_with_null_first_in_input_range() {
-        // Test that null at the beginning of input_range produces null first in sort
+        // Test that null at the beginning of input_range gets index 0
         use crate::plot::scale::Scale;
-
-        let mut facet_def = json!({"field": "__ggsql_aes_facet1__", "type": "nominal"});
 
         // Create a scale with null at the beginning
         let mut scale = Scale::new("facet1");
@@ -2334,14 +2459,127 @@ mod tests {
             ArrayElement::String("Gentoo".to_string()),
         ]);
 
-        apply_facet_ordering(&mut facet_def, Some(&scale));
+        let index_map = resolve_facet_ordering(Some(&scale));
 
-        // Verify null is first in sort order
+        // Verify null is at index 0 (first)
+        assert_eq!(index_map[0], (Value::Null, 0));
+        assert_eq!(index_map[1], (json!("Adelie"), 1));
+        assert_eq!(index_map[2], (json!("Gentoo"), 2));
+    }
+
+    #[test]
+    fn test_binned_facet_reverse_sets_descending_sort() {
+        use crate::plot::scale::Scale;
+        use crate::plot::{ParameterValue, ScaleType};
+
+        let mut facet_def = json!({"field": "__ggsql_aes_facet1__", "type": "nominal"});
+
+        let mut scale = Scale::new("facet1");
+        scale.scale_type = Some(ScaleType::binned());
+        scale
+            .properties
+            .insert("reverse".to_string(), ParameterValue::Boolean(true));
+
+        apply_binned_facet_reverse(&mut facet_def, Some(&scale));
+
+        assert_eq!(facet_def["sort"], json!("descending"));
+    }
+
+    #[test]
+    fn test_binned_facet_reverse_noop_when_not_reversed() {
+        use crate::plot::scale::Scale;
+        use crate::plot::ScaleType;
+
+        let mut facet_def = json!({"field": "__ggsql_aes_facet1__", "type": "nominal"});
+
+        let mut scale = Scale::new("facet1");
+        scale.scale_type = Some(ScaleType::binned());
+
+        apply_binned_facet_reverse(&mut facet_def, Some(&scale));
+
+        assert!(facet_def.get("sort").is_none());
+    }
+
+    #[test]
+    fn test_binned_facet_reverse_noop_for_discrete() {
+        use crate::plot::scale::Scale;
+
+        let mut facet_def = json!({"field": "__ggsql_aes_facet1__", "type": "nominal"});
+
+        let mut scale = Scale::new("facet1");
+        scale
+            .properties
+            .insert("reverse".to_string(), ParameterValue::Boolean(true));
+
+        apply_binned_facet_reverse(&mut facet_def, Some(&scale));
+
+        // Discrete scales should not get sort: "descending" — they use index reversal
+        assert!(facet_def.get("sort").is_none());
+    }
+
+    #[test]
+    fn test_indexed_facet_label_expr_basic() {
+        // Test that build_indexed_facet_label_expr maps integer indices to original labels
+        let index_map = vec![(json!("A"), 0), (json!("B"), 1), (json!("C"), 2)];
+
+        let expr = build_indexed_facet_label_expr(&index_map, None);
+
         assert_eq!(
-            facet_def["sort"],
-            json!([null, "Adelie", "Gentoo"]),
-            "Facet sort should preserve null at beginning"
+            expr,
+            "datum.value == 0 ? 'A' : datum.value == 1 ? 'B' : datum.value == 2 ? 'C' : datum.value"
         );
+    }
+
+    #[test]
+    fn test_indexed_facet_label_expr_with_renaming() {
+        // Test that user label_mapping (RENAMING clause) overrides the original values
+        let index_map = vec![(json!("A"), 0), (json!("B"), 1), (json!("C"), 2)];
+
+        let mut label_mapping = HashMap::new();
+        label_mapping.insert("A".to_string(), Some("Alpha".to_string()));
+        label_mapping.insert("C".to_string(), Some("Charlie".to_string()));
+
+        let expr = build_indexed_facet_label_expr(&index_map, Some(&label_mapping));
+
+        // A and C are renamed; B keeps its original label
+        assert!(expr.contains("datum.value == 0 ? 'Alpha'"), "got: {}", expr);
+        assert!(expr.contains("datum.value == 1 ? 'B'"), "got: {}", expr);
+        assert!(
+            expr.contains("datum.value == 2 ? 'Charlie'"),
+            "got: {}",
+            expr
+        );
+    }
+
+    #[test]
+    fn test_indexed_facet_label_expr_with_null() {
+        // Test that null values in the index map produce correct label mapping
+        let index_map = vec![(json!("Adelie"), 0), (json!("Gentoo"), 1), (Value::Null, 2)];
+
+        let mut label_mapping = HashMap::new();
+        label_mapping.insert("null".to_string(), Some("Missing".to_string()));
+
+        let expr = build_indexed_facet_label_expr(&index_map, Some(&label_mapping));
+
+        assert!(
+            expr.contains("datum.value == 2 ? 'Missing'"),
+            "got: {}",
+            expr
+        );
+    }
+
+    #[test]
+    fn test_indexed_facet_label_expr_suppressed_label() {
+        // Test that NULL in label_mapping suppresses the label (maps to empty string)
+        let index_map = vec![(json!("A"), 0), (json!("B"), 1)];
+
+        let mut label_mapping = HashMap::new();
+        label_mapping.insert("A".to_string(), None);
+
+        let expr = build_indexed_facet_label_expr(&index_map, Some(&label_mapping));
+
+        assert!(expr.contains("datum.value == 0 ? ''"), "got: {}", expr);
+        assert!(expr.contains("datum.value == 1 ? 'B'"), "got: {}", expr);
     }
 
     #[test]


### PR DESCRIPTION
This PR aims to fix #409.

Briefly the `"facet": {"column/row": {"sort": [...]}}` sorting array is buggy upstream in VL. We circumvent the upstream problem by converting our facet columns to integer indices by matching these to the facet order. This causes the panels to sort themselves naturally in VL.

There is a small effort at code duplication as well.