### PR TITLE
Support predicates in function arguments

### DIFF
--- a/src/parser/builder.rs
+++ b/src/parser/builder.rs
@@ -1936,6 +1936,32 @@ mod tests {
         assert!(result.is_ok());
     }
 
+    #[test]
+    fn test_boolean_operators_in_function_args() {
+        let query = r#"
+            SELECT IFF(x = 'a' OR x = 'b', 1, 0) AS rate
+            FROM t
+            VISUALISE rate AS x
+            DRAW point
+        "#;
+
+        let result = parse_test_query(query);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_and_operator_in_function_args() {
+        let query = r#"
+            SELECT IFF(x > 0 AND x < 10, 1, 0) AS flag
+            FROM t
+            VISUALISE flag AS x
+            DRAW point
+        "#;
+
+        let result = parse_test_query(query);
+        assert!(result.is_ok());
+    }
+
     // ========================================
     // Negative Test Cases - Should Error
     // ========================================
@@ -1984,6 +2010,32 @@ mod tests {
         let query = r#"
             SELECT a.* FROM a JOIN b ON a.id = b.id
             VISUALISE FROM c
+        "#;
+
+        let result = parse_test_query(query);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_error_between_in_function_args() {
+        let query = r#"
+            SELECT IFF(x BETWEEN 1 AND 10, 1, 0) AS flag
+            FROM t
+            VISUALISE flag AS x
+            DRAW point
+        "#;
+
+        let result = parse_test_query(query);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_error_not_operator_in_function_args() {
+        let query = r#"
+            SELECT IFF(NOT x = 'a', 1, 0) AS flag
+            FROM t
+            VISUALISE flag AS x
+            DRAW point
         "#;
 
         let result = parse_test_query(query);

--- a/src/parser/builder.rs
+++ b/src/parser/builder.rs
@@ -2053,6 +2053,19 @@ mod tests {
         assert!(result.is_ok());
     }
 
+    #[test]
+    fn test_named_arg_predicate_in_function_args() {
+        let query = r#"
+            SELECT FOO(flag => x = 'a' OR x = 'b')
+            FROM t
+            VISUALISE x AS x
+            DRAW point
+        "#;
+
+        let result = parse_test_query(query);
+        assert!(result.is_ok());
+    }
+
     // ========================================
     // Negative Test Cases - Should Error
     // ========================================

--- a/src/parser/builder.rs
+++ b/src/parser/builder.rs
@@ -1962,6 +1962,97 @@ mod tests {
         assert!(result.is_ok());
     }
 
+    #[test]
+    fn test_between_in_function_args() {
+        let query = r#"
+            SELECT IFF(x BETWEEN 1 AND 10, 1, 0) AS flag
+            FROM t
+            VISUALISE flag AS x
+            DRAW point
+        "#;
+
+        let result = parse_test_query(query);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_not_operator_in_function_args() {
+        let query = r#"
+            SELECT IFF(NOT x = 'a', 1, 0) AS flag
+            FROM t
+            VISUALISE flag AS x
+            DRAW point
+        "#;
+
+        let result = parse_test_query(query);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_in_predicate_in_function_args() {
+        let query = r#"
+            SELECT IFF(x IN ('a', 'b'), 1, 0) AS flag
+            FROM t
+            VISUALISE flag AS x
+            DRAW point
+        "#;
+
+        let result = parse_test_query(query);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_not_in_predicate_in_function_args() {
+        let query = r#"
+            SELECT IFF(x NOT IN ('a', 'b'), 1, 0) AS flag
+            FROM t
+            VISUALISE flag AS x
+            DRAW point
+        "#;
+
+        let result = parse_test_query(query);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_is_null_in_function_args() {
+        let query = r#"
+            SELECT IFF(x IS NULL, 1, 0) AS flag
+            FROM t
+            VISUALISE flag AS x
+            DRAW point
+        "#;
+
+        let result = parse_test_query(query);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_like_predicate_in_function_args() {
+        let query = r#"
+            SELECT IFF(x LIKE 'a%', 1, 0) AS flag
+            FROM t
+            VISUALISE flag AS x
+            DRAW point
+        "#;
+
+        let result = parse_test_query(query);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_ilike_predicate_in_function_args() {
+        let query = r#"
+            SELECT IFF(x ILIKE 'a%', 1, 0) AS flag
+            FROM t
+            VISUALISE flag AS x
+            DRAW point
+        "#;
+
+        let result = parse_test_query(query);
+        assert!(result.is_ok());
+    }
+
     // ========================================
     // Negative Test Cases - Should Error
     // ========================================
@@ -2014,71 +2105,6 @@ mod tests {
 
         let result = parse_test_query(query);
         assert!(result.is_err());
-    }
-
-    #[test]
-    fn test_between_in_function_args() {
-        let query = r#"
-            SELECT IFF(x BETWEEN 1 AND 10, 1, 0) AS flag
-            FROM t
-            VISUALISE flag AS x
-            DRAW point
-        "#;
-
-        let result = parse_test_query(query);
-        assert!(result.is_ok());
-    }
-
-    #[test]
-    fn test_not_operator_in_function_args() {
-        let query = r#"
-            SELECT IFF(NOT x = 'a', 1, 0) AS flag
-            FROM t
-            VISUALISE flag AS x
-            DRAW point
-        "#;
-
-        let result = parse_test_query(query);
-        assert!(result.is_ok());
-    }
-
-    #[test]
-    fn test_in_predicate_in_function_args() {
-        let query = r#"
-            SELECT IFF(x IN ('a', 'b'), 1, 0) AS flag
-            FROM t
-            VISUALISE flag AS x
-            DRAW point
-        "#;
-
-        let result = parse_test_query(query);
-        assert!(result.is_ok());
-    }
-
-    #[test]
-    fn test_is_null_in_function_args() {
-        let query = r#"
-            SELECT IFF(x IS NULL, 1, 0) AS flag
-            FROM t
-            VISUALISE flag AS x
-            DRAW point
-        "#;
-
-        let result = parse_test_query(query);
-        assert!(result.is_ok());
-    }
-
-    #[test]
-    fn test_like_predicate_in_function_args() {
-        let query = r#"
-            SELECT IFF(x LIKE 'a%', 1, 0) AS flag
-            FROM t
-            VISUALISE flag AS x
-            DRAW point
-        "#;
-
-        let result = parse_test_query(query);
-        assert!(result.is_ok());
     }
 
     // ========================================

--- a/src/parser/builder.rs
+++ b/src/parser/builder.rs
@@ -2054,6 +2054,17 @@ mod tests {
     }
 
     #[test]
+    fn test_extract_named_arg_predicate_value_spans_full_expression() {
+        let query = "SELECT FOO(flag => x = 'a' OR x = 'b') FROM t VISUALISE x AS x DRAW point";
+        let source = make_source(query);
+        let root = source.root();
+        let named_arg = source.find_node(&root, "(named_arg) @arg").unwrap();
+
+        let (_, value_node) = extract_name_value_nodes(&named_arg, "named_arg").unwrap();
+        assert_eq!(source.get_text(&value_node), "x = 'a' OR x = 'b'");
+    }
+
+    #[test]
     fn test_named_arg_predicate_in_function_args() {
         let query = r#"
             SELECT FOO(flag => x = 'a' OR x = 'b')

--- a/src/parser/builder.rs
+++ b/src/parser/builder.rs
@@ -2017,7 +2017,7 @@ mod tests {
     }
 
     #[test]
-    fn test_error_between_in_function_args() {
+    fn test_between_in_function_args() {
         let query = r#"
             SELECT IFF(x BETWEEN 1 AND 10, 1, 0) AS flag
             FROM t
@@ -2026,11 +2026,11 @@ mod tests {
         "#;
 
         let result = parse_test_query(query);
-        assert!(result.is_err());
+        assert!(result.is_ok());
     }
 
     #[test]
-    fn test_error_not_operator_in_function_args() {
+    fn test_not_operator_in_function_args() {
         let query = r#"
             SELECT IFF(NOT x = 'a', 1, 0) AS flag
             FROM t
@@ -2039,7 +2039,46 @@ mod tests {
         "#;
 
         let result = parse_test_query(query);
-        assert!(result.is_err());
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_in_predicate_in_function_args() {
+        let query = r#"
+            SELECT IFF(x IN ('a', 'b'), 1, 0) AS flag
+            FROM t
+            VISUALISE flag AS x
+            DRAW point
+        "#;
+
+        let result = parse_test_query(query);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_is_null_in_function_args() {
+        let query = r#"
+            SELECT IFF(x IS NULL, 1, 0) AS flag
+            FROM t
+            VISUALISE flag AS x
+            DRAW point
+        "#;
+
+        let result = parse_test_query(query);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_like_predicate_in_function_args() {
+        let query = r#"
+            SELECT IFF(x LIKE 'a%', 1, 0) AS flag
+            FROM t
+            VISUALISE flag AS x
+            DRAW point
+        "#;
+
+        let result = parse_test_query(query);
+        assert!(result.is_ok());
     }
 
     // ========================================

--- a/tree-sitter-ggsql/grammar.js
+++ b/tree-sitter-ggsql/grammar.js
@@ -492,8 +492,11 @@ module.exports = grammar({
       // Scalar subquery: (SELECT ...) or (WITH ... SELECT ...)
       $.scalar_subquery,
       // Arithmetic/comparison expression (binary operators)
-      seq($.position_arg, choice('+', '-', '*', '/', '%', '||', '::', '<', '>', '<=', '>=', '=', '!=', '<>',
-      ), $.position_arg),
+      seq(
+        $.position_arg,
+        choice('+', '-', '*', '/', '%', '||', '::', '<', '>', '<=', '>=', '=', '!=', '<>'),
+        $.position_arg
+      ),
       // Parenthesized expression
       seq('(', $.position_arg, ')')
     )),

--- a/tree-sitter-ggsql/grammar.js
+++ b/tree-sitter-ggsql/grammar.js
@@ -390,19 +390,19 @@ module.exports = grammar({
     // Function argument: position or named
     function_arg: $ => choice(
       $.named_arg,
-      $._function_arg_expression
+      $.function_arg_expression
     ),
 
     named_arg: $ => seq(
       field('name', $.identifier),
       choice(':=', '=>'),
-      field('value', $._function_arg_expression)
+      field('value', $.function_arg_expression)
     ),
 
     // Function arguments support a slightly richer predicate grammar than the
     // generic position_arg rule. Keep this scoped here so we don't widen SQL
     // parsing in other contexts by accident.
-    _function_arg_expression: $ => $._function_arg_or_expression,
+    function_arg_expression: $ => $._function_arg_or_expression,
 
     _function_arg_or_expression: $ => prec.left(seq(
       $._function_arg_and_expression,
@@ -430,7 +430,7 @@ module.exports = grammar({
       $.is_predicate,
       $.like_predicate,
       $.position_arg,
-      prec(1, seq('(', $._function_arg_expression, ')'))
+      prec(1, seq('(', $.function_arg_expression, ')'))
     ),
 
     between_predicate: $ => seq(

--- a/tree-sitter-ggsql/grammar.js
+++ b/tree-sitter-ggsql/grammar.js
@@ -419,8 +419,10 @@ module.exports = grammar({
       $.function_call,
       // Scalar subquery: (SELECT ...) or (WITH ... SELECT ...)
       $.scalar_subquery,
-      // Arithmetic/comparison expression (binary operators)
-      seq($.position_arg, choice('+', '-', '*', '/', '%', '||', '::', '<', '>', '<=', '>=', '=', '!=', '<>'), $.position_arg),
+      // Arithmetic/comparison/boolean expression (binary operators)
+      seq($.position_arg, choice('+', '-', '*', '/', '%', '||', '::', '<', '>', '<=', '>=', '=', '!=', '<>',
+        caseInsensitive('AND'), caseInsensitive('OR')
+      ), $.position_arg),
       // Parenthesized expression
       seq('(', $.position_arg, ')')
     )),

--- a/tree-sitter-ggsql/grammar.js
+++ b/tree-sitter-ggsql/grammar.js
@@ -23,6 +23,7 @@ module.exports = grammar({
 
   conflicts: $ => [
     [$.sql_portion],
+    [$._function_arg_predicate, $.position_arg],
   ],
 
   rules: {
@@ -389,13 +390,84 @@ module.exports = grammar({
     // Function argument: position or named
     function_arg: $ => choice(
       $.named_arg,
-      $.position_arg
+      $._function_arg_expression
     ),
 
     named_arg: $ => seq(
       field('name', $.identifier),
       choice(':=', '=>'),
-      field('value', $.position_arg)
+      field('value', $._function_arg_expression)
+    ),
+
+    // Function arguments support a slightly richer predicate grammar than the
+    // generic position_arg rule. Keep this scoped here so we don't widen SQL
+    // parsing in other contexts by accident.
+    _function_arg_expression: $ => $._function_arg_or_expression,
+
+    _function_arg_or_expression: $ => prec.left(seq(
+      $._function_arg_and_expression,
+      repeat(seq(caseInsensitive('OR'), $._function_arg_and_expression))
+    )),
+
+    _function_arg_and_expression: $ => prec.left(seq(
+      $._function_arg_not_expression,
+      repeat(seq(caseInsensitive('AND'), $._function_arg_not_expression))
+    )),
+
+    _function_arg_not_expression: $ => choice(
+      $.not_predicate,
+      $._function_arg_predicate
+    ),
+
+    not_predicate: $ => prec.right(seq(
+      caseInsensitive('NOT'),
+      $._function_arg_not_expression
+    )),
+
+    _function_arg_predicate: $ => choice(
+      $.between_predicate,
+      $.in_predicate,
+      $.is_predicate,
+      $.like_predicate,
+      $.position_arg,
+      prec(1, seq('(', $._function_arg_expression, ')'))
+    ),
+
+    between_predicate: $ => seq(
+      $.position_arg,
+      optional(caseInsensitive('NOT')),
+      caseInsensitive('BETWEEN'),
+      $.position_arg,
+      caseInsensitive('AND'),
+      $.position_arg
+    ),
+
+    in_predicate: $ => seq(
+      $.position_arg,
+      optional(caseInsensitive('NOT')),
+      caseInsensitive('IN'),
+      choice($.in_value_list, $.scalar_subquery)
+    ),
+
+    in_value_list: $ => seq(
+      '(',
+      $.position_arg,
+      repeat(seq(',', $.position_arg)),
+      ')'
+    ),
+
+    is_predicate: $ => seq(
+      $.position_arg,
+      caseInsensitive('IS'),
+      optional(caseInsensitive('NOT')),
+      caseInsensitive('NULL')
+    ),
+
+    like_predicate: $ => seq(
+      $.position_arg,
+      optional(caseInsensitive('NOT')),
+      choice(caseInsensitive('LIKE'), caseInsensitive('ILIKE')),
+      $.position_arg
     ),
 
     // Position argument: supports complex expressions including:
@@ -419,9 +491,8 @@ module.exports = grammar({
       $.function_call,
       // Scalar subquery: (SELECT ...) or (WITH ... SELECT ...)
       $.scalar_subquery,
-      // Arithmetic/comparison/boolean expression (binary operators)
+      // Arithmetic/comparison expression (binary operators)
       seq($.position_arg, choice('+', '-', '*', '/', '%', '||', '::', '<', '>', '<=', '>=', '=', '!=', '<>',
-        caseInsensitive('AND'), caseInsensitive('OR')
       ), $.position_arg),
       // Parenthesized expression
       seq('(', $.position_arg, ')')

--- a/tree-sitter-ggsql/grammar.js
+++ b/tree-sitter-ggsql/grammar.js
@@ -23,7 +23,6 @@ module.exports = grammar({
 
   conflicts: $ => [
     [$.sql_portion],
-    [$._function_arg_predicate, $.position_arg],
   ],
 
   rules: {
@@ -400,11 +399,8 @@ module.exports = grammar({
     ),
 
     // Function arguments support a slightly richer predicate grammar than the
-    // generic position_arg rule. Keep this scoped here so we don't widen SQL
-    // parsing in other contexts by accident.
-    function_arg_expression: $ => $._function_arg_or_expression,
-
-    _function_arg_or_expression: $ => prec.left(seq(
+    // generic position_arg rule.
+    function_arg_expression: $ => prec.left(seq(
       $._function_arg_and_expression,
       repeat(seq(caseInsensitive('OR'), $._function_arg_and_expression))
     )),
@@ -424,17 +420,19 @@ module.exports = grammar({
       $._function_arg_not_expression
     )),
 
-    _function_arg_predicate: $ => choice(
-      $.between_predicate,
-      $.in_predicate,
-      $.is_predicate,
-      $.like_predicate,
+    _function_arg_predicate: $ => seq(
       $.position_arg,
-      prec(1, seq('(', $.function_arg_expression, ')'))
+      optional($._predicate_suffix)
     ),
 
-    between_predicate: $ => seq(
-      $.position_arg,
+    _predicate_suffix: $ => choice(
+      $.between_suffix,
+      $.in_suffix,
+      $.is_suffix,
+      $.like_suffix,
+    ),
+
+    between_suffix: $ => seq(
       optional(caseInsensitive('NOT')),
       caseInsensitive('BETWEEN'),
       $.position_arg,
@@ -442,8 +440,7 @@ module.exports = grammar({
       $.position_arg
     ),
 
-    in_predicate: $ => seq(
-      $.position_arg,
+    in_suffix: $ => seq(
       optional(caseInsensitive('NOT')),
       caseInsensitive('IN'),
       choice($.in_value_list, $.scalar_subquery)
@@ -456,15 +453,13 @@ module.exports = grammar({
       ')'
     ),
 
-    is_predicate: $ => seq(
-      $.position_arg,
+    is_suffix: $ => seq(
       caseInsensitive('IS'),
       optional(caseInsensitive('NOT')),
       caseInsensitive('NULL')
     ),
 
-    like_predicate: $ => seq(
-      $.position_arg,
+    like_suffix: $ => seq(
       optional(caseInsensitive('NOT')),
       choice(caseInsensitive('LIKE'), caseInsensitive('ILIKE')),
       $.position_arg

--- a/tree-sitter-ggsql/test/corpus/basic.txt
+++ b/tree-sitter-ggsql/test/corpus/basic.txt
@@ -4044,6 +4044,123 @@ DRAW point
         (geom_type)))))
 
 ================================================================================
+ILIKE predicate in function arguments
+================================================================================
+
+SELECT IFF(x ILIKE 'a%', 1, 0) AS flag FROM t
+VISUALISE flag AS x
+DRAW point
+
+--------------------------------------------------------------------------------
+
+(query
+  (sql_portion
+    (sql_statement
+      (select_statement
+        (select_body
+          (function_call
+            (identifier
+              (bare_identifier))
+            (function_args
+              (function_arg
+                (like_predicate
+                  (position_arg
+                    (qualified_name
+                      (identifier
+                        (bare_identifier))))
+                  (position_arg
+                    (string))))
+              (function_arg
+                (position_arg
+                  (number)))
+              (function_arg
+                (position_arg
+                  (number)))))
+          (identifier
+            (bare_identifier))
+          (identifier
+            (bare_identifier))
+          (from_clause
+            (table_ref
+              table: (qualified_name
+                (identifier
+                  (bare_identifier)))))))))
+  (visualise_statement
+    (visualise_keyword)
+    (global_mapping
+      (mapping_list
+        (mapping_element
+          (explicit_mapping
+            value: (mapping_value
+              (column_reference
+                (identifier
+                  (bare_identifier))))
+            name: (aesthetic_name)))))
+    (viz_clause
+      (draw_clause
+        (geom_type)))))
+
+================================================================================
+NOT IN predicate in function arguments
+================================================================================
+
+SELECT IFF(x NOT IN ('a', 'b'), 1, 0) AS flag FROM t
+VISUALISE flag AS x
+DRAW point
+
+--------------------------------------------------------------------------------
+
+(query
+  (sql_portion
+    (sql_statement
+      (select_statement
+        (select_body
+          (function_call
+            (identifier
+              (bare_identifier))
+            (function_args
+              (function_arg
+                (in_predicate
+                  (position_arg
+                    (qualified_name
+                      (identifier
+                        (bare_identifier))))
+                  (in_value_list
+                    (position_arg
+                      (string))
+                    (position_arg
+                      (string)))))
+              (function_arg
+                (position_arg
+                  (number)))
+              (function_arg
+                (position_arg
+                  (number)))))
+          (identifier
+            (bare_identifier))
+          (identifier
+            (bare_identifier))
+          (from_clause
+            (table_ref
+              table: (qualified_name
+                (identifier
+                  (bare_identifier)))))))))
+  (visualise_statement
+    (visualise_keyword)
+    (global_mapping
+      (mapping_list
+        (mapping_element
+          (explicit_mapping
+            value: (mapping_value
+              (column_reference
+                (identifier
+                  (bare_identifier))))
+            name: (aesthetic_name)))))
+    (viz_clause
+      (draw_clause
+        (geom_type)))))
+
+================================================================================
 Layer source with Jinja ref
 ================================================================================
 

--- a/tree-sitter-ggsql/test/corpus/basic.txt
+++ b/tree-sitter-ggsql/test/corpus/basic.txt
@@ -4161,6 +4161,63 @@ DRAW point
         (geom_type)))))
 
 ================================================================================
+Named argument with predicate expression
+================================================================================
+
+SELECT FOO(flag => x = 'a' OR x = 'b') FROM t
+VISUALISE x AS x
+DRAW point
+
+--------------------------------------------------------------------------------
+
+(query
+  (sql_portion
+    (sql_statement
+      (select_statement
+        (select_body
+          (function_call
+            (identifier
+              (bare_identifier))
+            (function_args
+              (function_arg
+                (named_arg
+                  name: (identifier
+                    (bare_identifier))
+                  value: (position_arg
+                    (position_arg
+                      (qualified_name
+                        (identifier
+                          (bare_identifier))))
+                    (position_arg
+                      (string)))
+                  value: (position_arg
+                    (position_arg
+                      (qualified_name
+                        (identifier
+                          (bare_identifier))))
+                    (position_arg
+                      (string)))))))
+          (from_clause
+            (table_ref
+              table: (qualified_name
+                (identifier
+                  (bare_identifier)))))))))
+  (visualise_statement
+    (visualise_keyword)
+    (global_mapping
+      (mapping_list
+        (mapping_element
+          (explicit_mapping
+            value: (mapping_value
+              (column_reference
+                (identifier
+                  (bare_identifier))))
+            name: (aesthetic_name)))))
+    (viz_clause
+      (draw_clause
+        (geom_type)))))
+
+================================================================================
 Layer source with Jinja ref
 ================================================================================
 

--- a/tree-sitter-ggsql/test/corpus/basic.txt
+++ b/tree-sitter-ggsql/test/corpus/basic.txt
@@ -1360,10 +1360,11 @@ DRAW line MAPPING x AS x, total AS y
               (bare_identifier))
             (function_args
               (function_arg
-                (position_arg
-                  (qualified_name
-                    (identifier
-                      (bare_identifier))))))
+                (function_arg_expression
+                  (position_arg
+                    (qualified_name
+                      (identifier
+                        (bare_identifier)))))))
             (window_specification
               (window_order_clause
                 (order_item
@@ -1484,14 +1485,16 @@ DRAW point MAPPING interval AS x
                 (named_arg
                   name: (identifier
                     (bare_identifier))
-                  value: (position_arg
-                    (number))))
+                  value: (function_arg_expression
+                    (position_arg
+                      (number)))))
               (function_arg
                 (named_arg
                   name: (identifier
                     (bare_identifier))
-                  value: (position_arg
-                    (number))))))
+                  value: (function_arg_expression
+                    (position_arg
+                      (number)))))))
           (identifier
             (bare_identifier))
           (identifier
@@ -2548,15 +2551,16 @@ SELECT SUM(TRY_CAST(price AS INTEGER)) as total FROM data VISUALISE DRAW bar MAP
               (bare_identifier))
             (function_args
               (function_arg
-                (position_arg
-                  (cast_expression
-                    (position_arg
-                      (qualified_name
+                (function_arg_expression
+                  (position_arg
+                    (cast_expression
+                      (position_arg
+                        (qualified_name
+                          (identifier
+                            (bare_identifier))))
+                      (type_name
                         (identifier
-                          (bare_identifier))))
-                    (type_name
-                      (identifier
-                        (bare_identifier))))))))
+                          (bare_identifier)))))))))
           (identifier
             (bare_identifier))
           (identifier
@@ -2601,35 +2605,39 @@ DRAW point MAPPING x AS x
               (bare_identifier))
             (function_args
               (function_arg
-                (position_arg
-                  (function_call
-                    (identifier
-                      (bare_identifier))
-                    (function_args
-                      (function_arg
-                        (position_arg
-                          (qualified_name
-                            (identifier
-                              (bare_identifier)))))))))
+                (function_arg_expression
+                  (position_arg
+                    (function_call
+                      (identifier
+                        (bare_identifier))
+                      (function_args
+                        (function_arg
+                          (function_arg_expression
+                            (position_arg
+                              (qualified_name
+                                (identifier
+                                  (bare_identifier)))))))))))
               (function_arg
-                (position_arg
-                  (scalar_subquery
-                    (select_statement
-                      (select_body
-                        (function_call
-                          (identifier
-                            (bare_identifier))
-                          (function_args
-                            (function_arg
-                              (position_arg
-                                (qualified_name
-                                  (identifier
-                                    (bare_identifier)))))))
-                        (from_clause
-                          (table_ref
-                            table: (qualified_name
-                              (identifier
-                                (bare_identifier))))))))))))
+                (function_arg_expression
+                  (position_arg
+                    (scalar_subquery
+                      (select_statement
+                        (select_body
+                          (function_call
+                            (identifier
+                              (bare_identifier))
+                            (function_args
+                              (function_arg
+                                (function_arg_expression
+                                  (position_arg
+                                    (qualified_name
+                                      (identifier
+                                        (bare_identifier))))))))
+                          (from_clause
+                            (table_ref
+                              table: (qualified_name
+                                (identifier
+                                  (bare_identifier)))))))))))))
           (from_clause
             (table_ref
               table: (qualified_name
@@ -3097,10 +3105,11 @@ SELECT COUNT(DISTINCT region) AS n FROM sales VISUALISE n AS x DRAW bar
             (set_quantifier)
             (function_args
               (function_arg
-                (position_arg
-                  (qualified_name
-                    (identifier
-                      (bare_identifier)))))))
+                (function_arg_expression
+                  (position_arg
+                    (qualified_name
+                      (identifier
+                        (bare_identifier))))))))
           (identifier
             (bare_identifier))
           (identifier
@@ -3144,10 +3153,11 @@ SELECT SUM(ALL price) AS total FROM sales VISUALISE total AS x DRAW bar
             (set_quantifier)
             (function_args
               (function_arg
-                (position_arg
-                  (qualified_name
-                    (identifier
-                      (bare_identifier)))))))
+                (function_arg_expression
+                  (position_arg
+                    (qualified_name
+                      (identifier
+                        (bare_identifier))))))))
           (identifier
             (bare_identifier))
           (identifier
@@ -3193,10 +3203,11 @@ SELECT x, COUNT(DISTINCT y) OVER (PARTITION BY x) AS n FROM data VISUALISE n AS 
             (set_quantifier)
             (function_args
               (function_arg
-                (position_arg
-                  (qualified_name
-                    (identifier
-                      (bare_identifier))))))
+                (function_arg_expression
+                  (position_arg
+                    (qualified_name
+                      (identifier
+                        (bare_identifier)))))))
             (window_specification
               (window_partition_clause
                 (identifier
@@ -3225,7 +3236,6 @@ SELECT x, COUNT(DISTINCT y) OVER (PARTITION BY x) AS n FROM data VISUALISE n AS 
       (draw_clause
         (geom_type)))))
 
-
 ================================================================================
 CASE expression inside aggregate function
 ================================================================================
@@ -3244,18 +3254,19 @@ SELECT COUNT(CASE WHEN x = 1 THEN 1 END) AS n FROM t VISUALISE n AS y DRAW bar
               (bare_identifier))
             (function_args
               (function_arg
-                (position_arg
-                  (case_expression
-                    (case_body_token)
-                    (case_body_token
-                      (identifier
-                        (bare_identifier)))
-                    (case_body_token)
-                    (case_body_token
-                      (number))
-                    (case_body_token)
-                    (case_body_token
-                      (number)))))))
+                (function_arg_expression
+                  (position_arg
+                    (case_expression
+                      (case_body_token)
+                      (case_body_token
+                        (identifier
+                          (bare_identifier)))
+                      (case_body_token)
+                      (case_body_token
+                        (number))
+                      (case_body_token)
+                      (case_body_token
+                        (number))))))))
           (identifier
             (bare_identifier))
           (identifier
@@ -3298,21 +3309,22 @@ SELECT SUM(CASE WHEN status = 'active' THEN 1 ELSE 0 END) AS n FROM t VISUALISE 
               (bare_identifier))
             (function_args
               (function_arg
-                (position_arg
-                  (case_expression
-                    (case_body_token)
-                    (case_body_token
-                      (identifier
-                        (bare_identifier)))
-                    (case_body_token)
-                    (case_body_token
-                      (string))
-                    (case_body_token)
-                    (case_body_token
-                      (number))
-                    (case_body_token)
-                    (case_body_token
-                      (number)))))))
+                (function_arg_expression
+                  (position_arg
+                    (case_expression
+                      (case_body_token)
+                      (case_body_token
+                        (identifier
+                          (bare_identifier)))
+                      (case_body_token)
+                      (case_body_token
+                        (string))
+                      (case_body_token)
+                      (case_body_token
+                        (number))
+                      (case_body_token)
+                      (case_body_token
+                        (number))))))))
           (identifier
             (bare_identifier))
           (identifier
@@ -3406,27 +3418,28 @@ SELECT COUNT(CASE WHEN CASE WHEN y = 1 THEN 'a' END = 'a' THEN 1 END) AS n FROM 
               (bare_identifier))
             (function_args
               (function_arg
-                (position_arg
-                  (case_expression
-                    (case_body_token)
-                    (case_body_token
-                      (case_expression
-                        (case_body_token)
-                        (case_body_token
-                          (identifier
-                            (bare_identifier)))
-                        (case_body_token)
-                        (case_body_token
-                          (number))
-                        (case_body_token)
-                        (case_body_token
-                          (string))))
-                    (case_body_token)
-                    (case_body_token
-                      (string))
-                    (case_body_token)
-                    (case_body_token
-                      (number)))))))
+                (function_arg_expression
+                  (position_arg
+                    (case_expression
+                      (case_body_token)
+                      (case_body_token
+                        (case_expression
+                          (case_body_token)
+                          (case_body_token
+                            (identifier
+                              (bare_identifier)))
+                          (case_body_token)
+                          (case_body_token
+                            (number))
+                          (case_body_token)
+                          (case_body_token
+                            (string))))
+                      (case_body_token)
+                      (case_body_token
+                        (string))
+                      (case_body_token)
+                      (case_body_token
+                        (number))))))))
           (identifier
             (bare_identifier))
           (identifier
@@ -3469,21 +3482,22 @@ SELECT COUNT(CASE WHEN status IN ('Charged Off', 'Default') THEN 1 END) AS n FRO
               (bare_identifier))
             (function_args
               (function_arg
-                (position_arg
-                  (case_expression
-                    (case_body_token)
-                    (case_body_token
-                      (identifier
-                        (bare_identifier)))
-                    (case_body_token)
-                    (case_body_token
-                      (subquery
-                        (subquery_body
-                          (string)
-                          (string))))
-                    (case_body_token)
-                    (case_body_token
-                      (number)))))))
+                (function_arg_expression
+                  (position_arg
+                    (case_expression
+                      (case_body_token)
+                      (case_body_token
+                        (identifier
+                          (bare_identifier)))
+                      (case_body_token)
+                      (case_body_token
+                        (subquery
+                          (subquery_body
+                            (string)
+                            (string))))
+                      (case_body_token)
+                      (case_body_token
+                        (number))))))))
           (identifier
             (bare_identifier))
           (identifier
@@ -3528,38 +3542,42 @@ SELECT grade, ROUND(COUNT(CASE WHEN status = 'Default' THEN 1 END) * 100.0 / COU
               (bare_identifier))
             (function_args
               (function_arg
-                (position_arg
+                (function_arg_expression
                   (position_arg
+                    (position_arg
+                      (position_arg
+                        (function_call
+                          (identifier
+                            (bare_identifier))
+                          (function_args
+                            (function_arg
+                              (function_arg_expression
+                                (position_arg
+                                  (case_expression
+                                    (case_body_token)
+                                    (case_body_token
+                                      (identifier
+                                        (bare_identifier)))
+                                    (case_body_token)
+                                    (case_body_token
+                                      (string))
+                                    (case_body_token)
+                                    (case_body_token
+                                      (number)))))))))
+                      (position_arg
+                        (number)))
                     (position_arg
                       (function_call
                         (identifier
                           (bare_identifier))
                         (function_args
                           (function_arg
-                            (position_arg
-                              (case_expression
-                                (case_body_token)
-                                (case_body_token
-                                  (identifier
-                                    (bare_identifier)))
-                                (case_body_token)
-                                (case_body_token
-                                  (string))
-                                (case_body_token)
-                                (case_body_token
-                                  (number))))))))
-                    (position_arg
-                      (number)))
-                  (position_arg
-                    (function_call
-                      (identifier
-                        (bare_identifier))
-                      (function_args
-                        (function_arg
-                          (position_arg)))))))
+                            (function_arg_expression
+                              (position_arg)))))))))
               (function_arg
-                (position_arg
-                  (number)))))
+                (function_arg_expression
+                  (position_arg
+                    (number))))))
           (identifier
             (bare_identifier))
           (identifier
@@ -3710,26 +3728,29 @@ DRAW point
               (bare_identifier))
             (function_args
               (function_arg
-                (position_arg
+                (function_arg_expression
                   (position_arg
-                    (qualified_name
-                      (identifier
-                        (bare_identifier))))
+                    (position_arg
+                      (qualified_name
+                        (identifier
+                          (bare_identifier))))
+                    (position_arg
+                      (string)))
                   (position_arg
-                    (string)))
-                (position_arg
-                  (position_arg
-                    (qualified_name
-                      (identifier
-                        (bare_identifier))))
-                  (position_arg
-                    (string))))
+                    (position_arg
+                      (qualified_name
+                        (identifier
+                          (bare_identifier))))
+                    (position_arg
+                      (string)))))
               (function_arg
-                (position_arg
-                  (number)))
+                (function_arg_expression
+                  (position_arg
+                    (number))))
               (function_arg
-                (position_arg
-                  (number)))))
+                (function_arg_expression
+                  (position_arg
+                    (number))))))
           (identifier
             (bare_identifier))
           (identifier
@@ -3774,20 +3795,23 @@ DRAW point
               (bare_identifier))
             (function_args
               (function_arg
-                (not_predicate
+                (function_arg_expression
+                  (not_predicate
+                    (position_arg
+                      (position_arg
+                        (qualified_name
+                          (identifier
+                            (bare_identifier))))
+                      (position_arg
+                        (string))))))
+              (function_arg
+                (function_arg_expression
                   (position_arg
-                    (position_arg
-                      (qualified_name
-                        (identifier
-                          (bare_identifier))))
-                    (position_arg
-                      (string)))))
+                    (number))))
               (function_arg
-                (position_arg
-                  (number)))
-              (function_arg
-                (position_arg
-                  (number)))))
+                (function_arg_expression
+                  (position_arg
+                    (number))))))
           (identifier
             (bare_identifier))
           (identifier
@@ -3832,22 +3856,25 @@ DRAW point
               (bare_identifier))
             (function_args
               (function_arg
-                (in_predicate
+                (function_arg_expression
+                  (in_predicate
+                    (position_arg
+                      (qualified_name
+                        (identifier
+                          (bare_identifier))))
+                    (in_value_list
+                      (position_arg
+                        (string))
+                      (position_arg
+                        (string))))))
+              (function_arg
+                (function_arg_expression
                   (position_arg
-                    (qualified_name
-                      (identifier
-                        (bare_identifier))))
-                  (in_value_list
-                    (position_arg
-                      (string))
-                    (position_arg
-                      (string)))))
+                    (number))))
               (function_arg
-                (position_arg
-                  (number)))
-              (function_arg
-                (position_arg
-                  (number)))))
+                (function_arg_expression
+                  (position_arg
+                    (number))))))
           (identifier
             (bare_identifier))
           (identifier
@@ -3892,21 +3919,24 @@ DRAW point
               (bare_identifier))
             (function_args
               (function_arg
-                (between_predicate
-                  (position_arg
-                    (qualified_name
-                      (identifier
-                        (bare_identifier))))
-                  (position_arg
-                    (number))
+                (function_arg_expression
+                  (between_predicate
+                    (position_arg
+                      (qualified_name
+                        (identifier
+                          (bare_identifier))))
+                    (position_arg
+                      (number))
+                    (position_arg
+                      (number)))))
+              (function_arg
+                (function_arg_expression
                   (position_arg
                     (number))))
               (function_arg
-                (position_arg
-                  (number)))
-              (function_arg
-                (position_arg
-                  (number)))))
+                (function_arg_expression
+                  (position_arg
+                    (number))))))
           (identifier
             (bare_identifier))
           (identifier
@@ -3951,17 +3981,20 @@ DRAW point
               (bare_identifier))
             (function_args
               (function_arg
-                (is_predicate
+                (function_arg_expression
+                  (is_predicate
+                    (position_arg
+                      (qualified_name
+                        (identifier
+                          (bare_identifier)))))))
+              (function_arg
+                (function_arg_expression
                   (position_arg
-                    (qualified_name
-                      (identifier
-                        (bare_identifier))))))
+                    (number))))
               (function_arg
-                (position_arg
-                  (number)))
-              (function_arg
-                (position_arg
-                  (number)))))
+                (function_arg_expression
+                  (position_arg
+                    (number))))))
           (identifier
             (bare_identifier))
           (identifier
@@ -4006,19 +4039,22 @@ DRAW point
               (bare_identifier))
             (function_args
               (function_arg
-                (like_predicate
-                  (position_arg
-                    (qualified_name
-                      (identifier
-                        (bare_identifier))))
-                  (position_arg
-                    (string))))
+                (function_arg_expression
+                  (like_predicate
+                    (position_arg
+                      (qualified_name
+                        (identifier
+                          (bare_identifier))))
+                    (position_arg
+                      (string)))))
               (function_arg
-                (position_arg
-                  (number)))
+                (function_arg_expression
+                  (position_arg
+                    (number))))
               (function_arg
-                (position_arg
-                  (number)))))
+                (function_arg_expression
+                  (position_arg
+                    (number))))))
           (identifier
             (bare_identifier))
           (identifier
@@ -4063,19 +4099,22 @@ DRAW point
               (bare_identifier))
             (function_args
               (function_arg
-                (like_predicate
-                  (position_arg
-                    (qualified_name
-                      (identifier
-                        (bare_identifier))))
-                  (position_arg
-                    (string))))
+                (function_arg_expression
+                  (like_predicate
+                    (position_arg
+                      (qualified_name
+                        (identifier
+                          (bare_identifier))))
+                    (position_arg
+                      (string)))))
               (function_arg
-                (position_arg
-                  (number)))
+                (function_arg_expression
+                  (position_arg
+                    (number))))
               (function_arg
-                (position_arg
-                  (number)))))
+                (function_arg_expression
+                  (position_arg
+                    (number))))))
           (identifier
             (bare_identifier))
           (identifier
@@ -4120,22 +4159,25 @@ DRAW point
               (bare_identifier))
             (function_args
               (function_arg
-                (in_predicate
+                (function_arg_expression
+                  (in_predicate
+                    (position_arg
+                      (qualified_name
+                        (identifier
+                          (bare_identifier))))
+                    (in_value_list
+                      (position_arg
+                        (string))
+                      (position_arg
+                        (string))))))
+              (function_arg
+                (function_arg_expression
                   (position_arg
-                    (qualified_name
-                      (identifier
-                        (bare_identifier))))
-                  (in_value_list
-                    (position_arg
-                      (string))
-                    (position_arg
-                      (string)))))
+                    (number))))
               (function_arg
-                (position_arg
-                  (number)))
-              (function_arg
-                (position_arg
-                  (number)))))
+                (function_arg_expression
+                  (position_arg
+                    (number))))))
           (identifier
             (bare_identifier))
           (identifier
@@ -4183,20 +4225,21 @@ DRAW point
                 (named_arg
                   name: (identifier
                     (bare_identifier))
-                  value: (position_arg
+                  value: (function_arg_expression
                     (position_arg
-                      (qualified_name
-                        (identifier
-                          (bare_identifier))))
+                      (position_arg
+                        (qualified_name
+                          (identifier
+                            (bare_identifier))))
+                      (position_arg
+                        (string)))
                     (position_arg
-                      (string)))
-                  value: (position_arg
-                    (position_arg
-                      (qualified_name
-                        (identifier
-                          (bare_identifier))))
-                    (position_arg
-                      (string)))))))
+                      (position_arg
+                        (qualified_name
+                          (identifier
+                            (bare_identifier))))
+                      (position_arg
+                        (string))))))))
           (from_clause
             (table_ref
               table: (qualified_name

--- a/tree-sitter-ggsql/test/corpus/basic.txt
+++ b/tree-sitter-ggsql/test/corpus/basic.txt
@@ -3691,6 +3691,71 @@ DRAW point
         (geom_type)))))
 
 ================================================================================
+Boolean operators in function arguments
+================================================================================
+
+SELECT IFF(x = 'a' OR x = 'b', 1, 0) AS rate FROM t
+VISUALISE rate AS x
+DRAW point
+
+--------------------------------------------------------------------------------
+
+(query
+  (sql_portion
+    (sql_statement
+      (select_statement
+        (select_body
+          (function_call
+            (identifier
+              (bare_identifier))
+            (function_args
+              (function_arg
+                (position_arg
+                  (position_arg
+                    (position_arg
+                      (position_arg
+                        (qualified_name
+                          (identifier
+                            (bare_identifier))))
+                      (position_arg
+                        (string)))
+                    (position_arg
+                      (qualified_name
+                        (identifier
+                          (bare_identifier)))))
+                  (position_arg
+                    (string))))
+              (function_arg
+                (position_arg
+                  (number)))
+              (function_arg
+                (position_arg
+                  (number)))))
+          (identifier
+            (bare_identifier))
+          (identifier
+            (bare_identifier))
+          (from_clause
+            (table_ref
+              table: (qualified_name
+                (identifier
+                  (bare_identifier)))))))))
+  (visualise_statement
+    (visualise_keyword)
+    (global_mapping
+      (mapping_list
+        (mapping_element
+          (explicit_mapping
+            value: (mapping_value
+              (column_reference
+                (identifier
+                  (bare_identifier))))
+            name: (aesthetic_name)))))
+    (viz_clause
+      (draw_clause
+        (geom_type)))))
+
+================================================================================
 Layer source with Jinja ref
 ================================================================================
 

--- a/tree-sitter-ggsql/test/corpus/basic.txt
+++ b/tree-sitter-ggsql/test/corpus/basic.txt
@@ -3712,17 +3712,305 @@ DRAW point
               (function_arg
                 (position_arg
                   (position_arg
-                    (position_arg
-                      (position_arg
-                        (qualified_name
-                          (identifier
-                            (bare_identifier))))
-                      (position_arg
-                        (string)))
+                    (qualified_name
+                      (identifier
+                        (bare_identifier))))
+                  (position_arg
+                    (string)))
+                (position_arg
+                  (position_arg
+                    (qualified_name
+                      (identifier
+                        (bare_identifier))))
+                  (position_arg
+                    (string))))
+              (function_arg
+                (position_arg
+                  (number)))
+              (function_arg
+                (position_arg
+                  (number)))))
+          (identifier
+            (bare_identifier))
+          (identifier
+            (bare_identifier))
+          (from_clause
+            (table_ref
+              table: (qualified_name
+                (identifier
+                  (bare_identifier)))))))))
+  (visualise_statement
+    (visualise_keyword)
+    (global_mapping
+      (mapping_list
+        (mapping_element
+          (explicit_mapping
+            value: (mapping_value
+              (column_reference
+                (identifier
+                  (bare_identifier))))
+            name: (aesthetic_name)))))
+    (viz_clause
+      (draw_clause
+        (geom_type)))))
+
+================================================================================
+NOT predicate in function arguments
+================================================================================
+
+SELECT IFF(NOT x = 'a', 1, 0) AS flag FROM t
+VISUALISE flag AS x
+DRAW point
+
+--------------------------------------------------------------------------------
+
+(query
+  (sql_portion
+    (sql_statement
+      (select_statement
+        (select_body
+          (function_call
+            (identifier
+              (bare_identifier))
+            (function_args
+              (function_arg
+                (not_predicate
+                  (position_arg
                     (position_arg
                       (qualified_name
                         (identifier
-                          (bare_identifier)))))
+                          (bare_identifier))))
+                    (position_arg
+                      (string)))))
+              (function_arg
+                (position_arg
+                  (number)))
+              (function_arg
+                (position_arg
+                  (number)))))
+          (identifier
+            (bare_identifier))
+          (identifier
+            (bare_identifier))
+          (from_clause
+            (table_ref
+              table: (qualified_name
+                (identifier
+                  (bare_identifier)))))))))
+  (visualise_statement
+    (visualise_keyword)
+    (global_mapping
+      (mapping_list
+        (mapping_element
+          (explicit_mapping
+            value: (mapping_value
+              (column_reference
+                (identifier
+                  (bare_identifier))))
+            name: (aesthetic_name)))))
+    (viz_clause
+      (draw_clause
+        (geom_type)))))
+
+================================================================================
+IN predicate in function arguments
+================================================================================
+
+SELECT IFF(x IN ('a', 'b'), 1, 0) AS flag FROM t
+VISUALISE flag AS x
+DRAW point
+
+--------------------------------------------------------------------------------
+
+(query
+  (sql_portion
+    (sql_statement
+      (select_statement
+        (select_body
+          (function_call
+            (identifier
+              (bare_identifier))
+            (function_args
+              (function_arg
+                (in_predicate
+                  (position_arg
+                    (qualified_name
+                      (identifier
+                        (bare_identifier))))
+                  (in_value_list
+                    (position_arg
+                      (string))
+                    (position_arg
+                      (string)))))
+              (function_arg
+                (position_arg
+                  (number)))
+              (function_arg
+                (position_arg
+                  (number)))))
+          (identifier
+            (bare_identifier))
+          (identifier
+            (bare_identifier))
+          (from_clause
+            (table_ref
+              table: (qualified_name
+                (identifier
+                  (bare_identifier)))))))))
+  (visualise_statement
+    (visualise_keyword)
+    (global_mapping
+      (mapping_list
+        (mapping_element
+          (explicit_mapping
+            value: (mapping_value
+              (column_reference
+                (identifier
+                  (bare_identifier))))
+            name: (aesthetic_name)))))
+    (viz_clause
+      (draw_clause
+        (geom_type)))))
+
+================================================================================
+BETWEEN predicate in function arguments
+================================================================================
+
+SELECT IFF(x BETWEEN 1 AND 10, 1, 0) AS flag FROM t
+VISUALISE flag AS x
+DRAW point
+
+--------------------------------------------------------------------------------
+
+(query
+  (sql_portion
+    (sql_statement
+      (select_statement
+        (select_body
+          (function_call
+            (identifier
+              (bare_identifier))
+            (function_args
+              (function_arg
+                (between_predicate
+                  (position_arg
+                    (qualified_name
+                      (identifier
+                        (bare_identifier))))
+                  (position_arg
+                    (number))
+                  (position_arg
+                    (number))))
+              (function_arg
+                (position_arg
+                  (number)))
+              (function_arg
+                (position_arg
+                  (number)))))
+          (identifier
+            (bare_identifier))
+          (identifier
+            (bare_identifier))
+          (from_clause
+            (table_ref
+              table: (qualified_name
+                (identifier
+                  (bare_identifier)))))))))
+  (visualise_statement
+    (visualise_keyword)
+    (global_mapping
+      (mapping_list
+        (mapping_element
+          (explicit_mapping
+            value: (mapping_value
+              (column_reference
+                (identifier
+                  (bare_identifier))))
+            name: (aesthetic_name)))))
+    (viz_clause
+      (draw_clause
+        (geom_type)))))
+
+================================================================================
+IS NULL predicate in function arguments
+================================================================================
+
+SELECT IFF(x IS NULL, 1, 0) AS flag FROM t
+VISUALISE flag AS x
+DRAW point
+
+--------------------------------------------------------------------------------
+
+(query
+  (sql_portion
+    (sql_statement
+      (select_statement
+        (select_body
+          (function_call
+            (identifier
+              (bare_identifier))
+            (function_args
+              (function_arg
+                (is_predicate
+                  (position_arg
+                    (qualified_name
+                      (identifier
+                        (bare_identifier))))))
+              (function_arg
+                (position_arg
+                  (number)))
+              (function_arg
+                (position_arg
+                  (number)))))
+          (identifier
+            (bare_identifier))
+          (identifier
+            (bare_identifier))
+          (from_clause
+            (table_ref
+              table: (qualified_name
+                (identifier
+                  (bare_identifier)))))))))
+  (visualise_statement
+    (visualise_keyword)
+    (global_mapping
+      (mapping_list
+        (mapping_element
+          (explicit_mapping
+            value: (mapping_value
+              (column_reference
+                (identifier
+                  (bare_identifier))))
+            name: (aesthetic_name)))))
+    (viz_clause
+      (draw_clause
+        (geom_type)))))
+
+================================================================================
+LIKE predicate in function arguments
+================================================================================
+
+SELECT IFF(x LIKE 'a%', 1, 0) AS flag FROM t
+VISUALISE flag AS x
+DRAW point
+
+--------------------------------------------------------------------------------
+
+(query
+  (sql_portion
+    (sql_statement
+      (select_statement
+        (select_body
+          (function_call
+            (identifier
+              (bare_identifier))
+            (function_args
+              (function_arg
+                (like_predicate
+                  (position_arg
+                    (qualified_name
+                      (identifier
+                        (bare_identifier))))
                   (position_arg
                     (string))))
               (function_arg

--- a/tree-sitter-ggsql/test/corpus/basic.txt
+++ b/tree-sitter-ggsql/test/corpus/basic.txt
@@ -3857,11 +3857,11 @@ DRAW point
             (function_args
               (function_arg
                 (function_arg_expression
-                  (in_predicate
-                    (position_arg
-                      (qualified_name
-                        (identifier
-                          (bare_identifier))))
+                  (position_arg
+                    (qualified_name
+                      (identifier
+                        (bare_identifier))))
+                  (in_suffix
                     (in_value_list
                       (position_arg
                         (string))
@@ -3920,11 +3920,11 @@ DRAW point
             (function_args
               (function_arg
                 (function_arg_expression
-                  (between_predicate
-                    (position_arg
-                      (qualified_name
-                        (identifier
-                          (bare_identifier))))
+                  (position_arg
+                    (qualified_name
+                      (identifier
+                        (bare_identifier))))
+                  (between_suffix
                     (position_arg
                       (number))
                     (position_arg
@@ -3982,11 +3982,11 @@ DRAW point
             (function_args
               (function_arg
                 (function_arg_expression
-                  (is_predicate
-                    (position_arg
-                      (qualified_name
-                        (identifier
-                          (bare_identifier)))))))
+                  (position_arg
+                    (qualified_name
+                      (identifier
+                        (bare_identifier))))
+                  (is_suffix)))
               (function_arg
                 (function_arg_expression
                   (position_arg
@@ -4040,11 +4040,11 @@ DRAW point
             (function_args
               (function_arg
                 (function_arg_expression
-                  (like_predicate
-                    (position_arg
-                      (qualified_name
-                        (identifier
-                          (bare_identifier))))
+                  (position_arg
+                    (qualified_name
+                      (identifier
+                        (bare_identifier))))
+                  (like_suffix
                     (position_arg
                       (string)))))
               (function_arg
@@ -4100,11 +4100,11 @@ DRAW point
             (function_args
               (function_arg
                 (function_arg_expression
-                  (like_predicate
-                    (position_arg
-                      (qualified_name
-                        (identifier
-                          (bare_identifier))))
+                  (position_arg
+                    (qualified_name
+                      (identifier
+                        (bare_identifier))))
+                  (like_suffix
                     (position_arg
                       (string)))))
               (function_arg
@@ -4160,11 +4160,11 @@ DRAW point
             (function_args
               (function_arg
                 (function_arg_expression
-                  (in_predicate
-                    (position_arg
-                      (qualified_name
-                        (identifier
-                          (bare_identifier))))
+                  (position_arg
+                    (qualified_name
+                      (identifier
+                        (bare_identifier))))
+                  (in_suffix
                     (in_value_list
                       (position_arg
                         (string))


### PR DESCRIPTION
Closes #456.

## Summary

This PR improves SQL parsing inside function arguments.

The first commit takes the minimal step needed for the original issue by allowing `AND` / `OR` in function arguments.

The second commit expands that same area to support additional predicate forms in function arguments and named function-argument values:
- `NOT`
- `IN (...)`
- `BETWEEN ... AND ...`
- `IS NULL`
- `LIKE` / `ILIKE`

Examples that now parse include:

```sql
SELECT IFF(x = 'a' OR x = 'b', 1, 0) AS rate FROM t
VISUALISE rate AS x
DRAW point
```

```sql
SELECT IFF(NOT x = 'a', 1, 0) AS flag FROM t
VISUALISE flag AS x
DRAW point
```

```sql
SELECT IFF(x IN ('a', 'b'), 1, 0) AS flag FROM t
VISUALISE flag AS x
DRAW point
```

```sql
SELECT IFF(x BETWEEN 1 AND 10, 1, 0) AS flag FROM t
VISUALISE flag AS x
DRAW point
```

## Scope

The richer predicate grammar is still scoped to function arguments rather than being applied to `position_arg` more generally. This keeps the change focused on the parser gap addressed by this PR instead of turning it into a broader SQL expression refactor.

## Verification

- `cargo test -p ggsql function_args -- --nocapture`
- `cd tree-sitter-ggsql && tree-sitter generate && tree-sitter test`
