### PR TITLE
Add BigQuery support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 ## [Unreleased]
 
 ### Added
+- New `BigQueryReader` for querying Google BigQuery via Application Default
+  Credentials, behind a new off-by-default `bigquery` feature flag. Connection
+  string: `bigquery://[PROJECT_ID[/DATASET]][?location=REGION]` — the project
+  defaults to whatever ADC or `GOOGLE_CLOUD_PROJECT` provides when omitted; the
+  optional dataset sets a default dataset context; location defaults to `US`.
+  VS Code / Positron and the Jupyter kernel both support BigQuery connections
+  via the same scheme.
 - New `AdbcReader<D: Driver>` for connecting to data sources via
   [ADBC](https://arrow.apache.org/adbc/) (Arrow Database Connectivity), behind
   a new off-by-default `adbc` feature flag. Generic over any concrete

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8,8 +8,8 @@ version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46b169525a7c41670fe95874103c7c6ce713ac699123f81a200bc31f9ad3b02e"
 dependencies = [
- "arrow-array",
- "arrow-schema",
+ "arrow-array 58.3.0",
+ "arrow-schema 58.3.0",
 ]
 
 [[package]]
@@ -19,9 +19,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5055538c63972f2a56854b855e1b85c21de4ee32afaba408658537bcae6f04f0"
 dependencies = [
  "adbc_core",
- "arrow-array",
- "arrow-buffer",
- "arrow-schema",
+ "arrow-array 58.3.0",
+ "arrow-buffer 58.3.0",
+ "arrow-schema 58.3.0",
  "datafusion",
  "datafusion-substrait",
  "prost",
@@ -36,8 +36,8 @@ checksum = "12aa1ae565ec6d45cfe71c20b5c2b3cbd6ba5d7176ecd0c0a448e970a93c35e4"
 dependencies = [
  "adbc_core",
  "adbc_ffi",
- "arrow-array",
- "arrow-schema",
+ "arrow-array 58.3.0",
+ "arrow-schema 58.3.0",
  "libloading",
  "path-slash",
  "regex",
@@ -53,8 +53,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6851c2ab953511cf7a244aadcbc0586442fd3c67dfe371457369048880dd513"
 dependencies = [
  "adbc_core",
- "arrow-array",
- "arrow-schema",
+ "arrow-array 58.3.0",
+ "arrow-schema 58.3.0",
 ]
 
 [[package]]
@@ -195,23 +195,56 @@ checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "arrow"
+version = "56.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fb98341a7e051bb79731ecb33ec00cbd6e0e315a542d6732b46d462c9215ea2"
+dependencies = [
+ "arrow-arith 56.2.1",
+ "arrow-array 56.2.1",
+ "arrow-buffer 56.2.1",
+ "arrow-cast 56.2.1",
+ "arrow-data 56.2.1",
+ "arrow-ipc 56.2.1",
+ "arrow-ord 56.2.1",
+ "arrow-row 56.2.1",
+ "arrow-schema 56.2.1",
+ "arrow-select 56.2.1",
+ "arrow-string 56.2.1",
+]
+
+[[package]]
+name = "arrow"
 version = "58.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "378530e55cd479eda3c14eb345310799717e6f76d0c332041e8487022166b471"
 dependencies = [
- "arrow-arith",
- "arrow-array",
- "arrow-buffer",
- "arrow-cast",
+ "arrow-arith 58.3.0",
+ "arrow-array 58.3.0",
+ "arrow-buffer 58.3.0",
+ "arrow-cast 58.3.0",
  "arrow-csv",
- "arrow-data",
- "arrow-ipc",
+ "arrow-data 58.3.0",
+ "arrow-ipc 58.3.0",
  "arrow-json",
- "arrow-ord",
- "arrow-row",
- "arrow-schema",
- "arrow-select",
- "arrow-string",
+ "arrow-ord 58.3.0",
+ "arrow-row 58.3.0",
+ "arrow-schema 58.3.0",
+ "arrow-select 58.3.0",
+ "arrow-string 58.3.0",
+]
+
+[[package]]
+name = "arrow-arith"
+version = "56.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce4751cbc4bcccfeeea79df9571ff1dc066d61e44723c7604d11c7937f5b560"
+dependencies = [
+ "arrow-array 56.2.1",
+ "arrow-buffer 56.2.1",
+ "arrow-data 56.2.1",
+ "arrow-schema 56.2.1",
+ "chrono",
+ "num",
 ]
 
 [[package]]
@@ -220,12 +253,28 @@ version = "58.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0ab212d2c1886e802f51c5212d78ebbcbb0bec980fff9dadc1eb8d45cd0b738"
 dependencies = [
- "arrow-array",
- "arrow-buffer",
- "arrow-data",
- "arrow-schema",
+ "arrow-array 58.3.0",
+ "arrow-buffer 58.3.0",
+ "arrow-data 58.3.0",
+ "arrow-schema 58.3.0",
  "chrono",
  "num-traits",
+]
+
+[[package]]
+name = "arrow-array"
+version = "56.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b02ccba2e977a3aabb4384036109ca32f552399a2bc0588f925f91ed073ce70c"
+dependencies = [
+ "ahash 0.8.12",
+ "arrow-buffer 56.2.1",
+ "arrow-data 56.2.1",
+ "arrow-schema 56.2.1",
+ "chrono",
+ "half",
+ "hashbrown 0.16.1",
+ "num",
 ]
 
 [[package]]
@@ -235,9 +284,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfd33d3e92f207444098c75b42de99d329562be0cf686b307b097cc52b4e999e"
 dependencies = [
  "ahash 0.8.12",
- "arrow-buffer",
- "arrow-data",
- "arrow-schema",
+ "arrow-buffer 58.3.0",
+ "arrow-data 58.3.0",
+ "arrow-schema 58.3.0",
  "chrono",
  "chrono-tz",
  "half",
@@ -245,6 +294,17 @@ dependencies = [
  "num-complex",
  "num-integer",
  "num-traits",
+]
+
+[[package]]
+name = "arrow-buffer"
+version = "56.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a90f8bece6a9ee316a699fbbfde368a206676a1206ce89b50f07937648e76c3c"
+dependencies = [
+ "bytes",
+ "half",
+ "num",
 ]
 
 [[package]]
@@ -261,16 +321,36 @@ dependencies = [
 
 [[package]]
 name = "arrow-cast"
+version = "56.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61ffe645cfb4e80b1ca37a3a106ce7b4af66ccdd60c655a57e6b9aab096164a7"
+dependencies = [
+ "arrow-array 56.2.1",
+ "arrow-buffer 56.2.1",
+ "arrow-data 56.2.1",
+ "arrow-schema 56.2.1",
+ "arrow-select 56.2.1",
+ "atoi",
+ "base64",
+ "chrono",
+ "half",
+ "lexical-core",
+ "num",
+ "ryu",
+]
+
+[[package]]
+name = "arrow-cast"
 version = "58.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c5aefb56a2c02e9e2b30746241058b85f8983f0fcff2ba0c6d09006e1cded7f"
 dependencies = [
- "arrow-array",
- "arrow-buffer",
- "arrow-data",
- "arrow-ord",
- "arrow-schema",
- "arrow-select",
+ "arrow-array 58.3.0",
+ "arrow-buffer 58.3.0",
+ "arrow-data 58.3.0",
+ "arrow-ord 58.3.0",
+ "arrow-schema 58.3.0",
+ "arrow-select 58.3.0",
  "atoi",
  "base64",
  "chrono",
@@ -287,9 +367,9 @@ version = "58.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e94e8cf7e517657a52b91ea1263acf38c4ca62a84655d72458a3359b12ab97de"
 dependencies = [
- "arrow-array",
- "arrow-cast",
- "arrow-schema",
+ "arrow-array 58.3.0",
+ "arrow-cast 58.3.0",
+ "arrow-schema 58.3.0",
  "chrono",
  "csv",
  "csv-core",
@@ -298,15 +378,41 @@ dependencies = [
 
 [[package]]
 name = "arrow-data"
+version = "56.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78468c813909465dd0f858950c8a0614eb63608134acf95c602ec21381258b28"
+dependencies = [
+ "arrow-buffer 56.2.1",
+ "arrow-schema 56.2.1",
+ "half",
+ "num",
+]
+
+[[package]]
+name = "arrow-data"
 version = "58.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c88210023a2bfee1896af366309a3028fc3bcbd6515fa29a7990ee1baa08ee0"
 dependencies = [
- "arrow-buffer",
- "arrow-schema",
+ "arrow-buffer 58.3.0",
+ "arrow-schema 58.3.0",
  "half",
  "num-integer",
  "num-traits",
+]
+
+[[package]]
+name = "arrow-ipc"
+version = "56.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31f88b0fbb33af28089ccd3e4dcd0ff09de46842168d00220b920f7231feddf5"
+dependencies = [
+ "arrow-array 56.2.1",
+ "arrow-buffer 56.2.1",
+ "arrow-data 56.2.1",
+ "arrow-schema 56.2.1",
+ "arrow-select 56.2.1",
+ "flatbuffers",
 ]
 
 [[package]]
@@ -315,11 +421,11 @@ version = "58.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "238438f0834483703d88896db6fe5a7138b2230debc31b34c0336c2996e3c64f"
 dependencies = [
- "arrow-array",
- "arrow-buffer",
- "arrow-data",
- "arrow-schema",
- "arrow-select",
+ "arrow-array 58.3.0",
+ "arrow-buffer 58.3.0",
+ "arrow-data 58.3.0",
+ "arrow-schema 58.3.0",
+ "arrow-select 58.3.0",
  "flatbuffers",
  "lz4_flex",
 ]
@@ -330,12 +436,12 @@ version = "58.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "205ca2119e6d679d5c133c6f30e68f027738d95ed948cf77677ea69c7800036b"
 dependencies = [
- "arrow-array",
- "arrow-buffer",
- "arrow-cast",
- "arrow-ord",
- "arrow-schema",
- "arrow-select",
+ "arrow-array 58.3.0",
+ "arrow-buffer 58.3.0",
+ "arrow-cast 58.3.0",
+ "arrow-ord 58.3.0",
+ "arrow-schema 58.3.0",
+ "arrow-select 58.3.0",
  "chrono",
  "half",
  "indexmap",
@@ -351,15 +457,41 @@ dependencies = [
 
 [[package]]
 name = "arrow-ord"
+version = "56.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aed58a38c3db0a2cf75ef70e3cb6bc4bd0da0a3d390de37c36139b31fae826e8"
+dependencies = [
+ "arrow-array 56.2.1",
+ "arrow-buffer 56.2.1",
+ "arrow-data 56.2.1",
+ "arrow-schema 56.2.1",
+ "arrow-select 56.2.1",
+]
+
+[[package]]
+name = "arrow-ord"
 version = "58.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bffd8fd2579286a5d63bac898159873e5094a79009940bcb42bbfce4f19f1d0"
 dependencies = [
- "arrow-array",
- "arrow-buffer",
- "arrow-data",
- "arrow-schema",
- "arrow-select",
+ "arrow-array 58.3.0",
+ "arrow-buffer 58.3.0",
+ "arrow-data 58.3.0",
+ "arrow-schema 58.3.0",
+ "arrow-select 58.3.0",
+]
+
+[[package]]
+name = "arrow-row"
+version = "56.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "079ced0517daf4f09b070d09ff641cee7cc331aa216bebcb25d1a6474ad53086"
+dependencies = [
+ "arrow-array 56.2.1",
+ "arrow-buffer 56.2.1",
+ "arrow-data 56.2.1",
+ "arrow-schema 56.2.1",
+ "half",
 ]
 
 [[package]]
@@ -368,12 +500,18 @@ version = "58.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bab5994731204603c73ba69267616c50f80780774c6bb0476f1f830625115e0c"
 dependencies = [
- "arrow-array",
- "arrow-buffer",
- "arrow-data",
- "arrow-schema",
+ "arrow-array 58.3.0",
+ "arrow-buffer 58.3.0",
+ "arrow-data 58.3.0",
+ "arrow-schema 58.3.0",
  "half",
 ]
+
+[[package]]
+name = "arrow-schema"
+version = "56.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a0d5eb3fe25337ff83e8333a08379bdd1540b0961b1c888f6e505d971c198e1"
 
 [[package]]
 name = "arrow-schema"
@@ -388,16 +526,47 @@ dependencies = [
 
 [[package]]
 name = "arrow-select"
+version = "56.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2368a78bd32902dba39d52519d70f63799c8b5dc8a9477129a30c2fd3dc70c19"
+dependencies = [
+ "ahash 0.8.12",
+ "arrow-array 56.2.1",
+ "arrow-buffer 56.2.1",
+ "arrow-data 56.2.1",
+ "arrow-schema 56.2.1",
+ "num",
+]
+
+[[package]]
+name = "arrow-select"
 version = "58.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8cd065c54172ac787cf3f2f8d4107e0d3fdc26edba76fdf4f4cc170258942222"
 dependencies = [
  "ahash 0.8.12",
- "arrow-array",
- "arrow-buffer",
- "arrow-data",
- "arrow-schema",
+ "arrow-array 58.3.0",
+ "arrow-buffer 58.3.0",
+ "arrow-data 58.3.0",
+ "arrow-schema 58.3.0",
  "num-traits",
+]
+
+[[package]]
+name = "arrow-string"
+version = "56.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dece58a130b9187756ded8bc071bd8ee9dd7a146566af244b297c7e632fd1ef7"
+dependencies = [
+ "arrow-array 56.2.1",
+ "arrow-buffer 56.2.1",
+ "arrow-data 56.2.1",
+ "arrow-schema 56.2.1",
+ "arrow-select 56.2.1",
+ "memchr",
+ "num",
+ "regex",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -406,11 +575,11 @@ version = "58.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29dd7cda3ab9692f43a2e4acc444d760cc17b12bb6d8232ddf64e9bab7c06b42"
 dependencies = [
- "arrow-array",
- "arrow-buffer",
- "arrow-data",
- "arrow-schema",
- "arrow-select",
+ "arrow-array 58.3.0",
+ "arrow-buffer 58.3.0",
+ "arrow-data 58.3.0",
+ "arrow-schema 58.3.0",
+ "arrow-select 58.3.0",
  "memchr",
  "num-traits",
  "regex",
@@ -422,6 +591,28 @@ name = "async-recursion"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "async-stream"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -474,6 +665,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "aws-lc-rs"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ec2f1fc3ec205783a5da9a7e6c1509cc69dedf09a1949e412c1e18469326d00"
+dependencies = [
+ "aws-lc-sys",
+ "untrusted 0.7.1",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.41.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a2f9779ce85b93ab6170dd940ad0169b5766ff848247aff13bb788b832fe3f4"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+]
+
+[[package]]
+name = "backon"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cffb0e931875b666fc4fcb20fee52e9bbd1ef836fd9e9e04ec21555f9f85f7ef"
+dependencies = [
+ "fastrand",
+ "tokio",
+]
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -490,6 +714,7 @@ dependencies = [
  "num-bigint",
  "num-integer",
  "num-traits",
+ "serde",
 ]
 
 [[package]]
@@ -710,10 +935,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
+
+[[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "memchr",
+]
 
 [[package]]
 name = "comfy-table"
@@ -783,6 +1027,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "980c2afde4af43d6a05c5be738f9eae595cff86dce1f38f88b95058a98c027f3"
 dependencies = [
  "crossterm 0.29.0",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -995,9 +1249,9 @@ dependencies = [
 
 [[package]]
 name = "dashmap"
-version = "6.1.0"
+version = "6.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
+checksum = "e6361d5c062261c78a176addb82d4c821ae42bed6089de0e12603cd25de2059c"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
@@ -1019,8 +1273,8 @@ version = "53.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93db0e623840612f7f2cd757f7e8a8922064192363732c88692e0870016e141b"
 dependencies = [
- "arrow",
- "arrow-schema",
+ "arrow 58.3.0",
+ "arrow-schema 58.3.0",
  "async-trait",
  "bytes",
  "chrono",
@@ -1068,9 +1322,9 @@ version = "53.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37cefde60b26a7f4ff61e9d2ff2833322f91df2b568d7238afe67bde5bdffb66"
 dependencies = [
- "arrow",
+ "arrow 58.3.0",
  "async-trait",
- "dashmap 6.1.0",
+ "dashmap 6.2.1",
  "datafusion-common",
  "datafusion-common-runtime",
  "datafusion-datasource",
@@ -1093,7 +1347,7 @@ version = "53.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17e112307715d6a7a331111a4c2330ff54bc237183511c319e3708a4cff431fb"
 dependencies = [
- "arrow",
+ "arrow 58.3.0",
  "async-trait",
  "datafusion-catalog",
  "datafusion-common",
@@ -1117,8 +1371,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d72a11ca44a95e1081870d3abb80c717496e8a7acb467a1d3e932bb636af5cc2"
 dependencies = [
  "ahash 0.8.12",
- "arrow",
- "arrow-ipc",
+ "arrow 58.3.0",
+ "arrow-ipc 58.3.0",
  "chrono",
  "half",
  "hashbrown 0.16.1",
@@ -1150,7 +1404,7 @@ version = "53.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e9fb386e1691355355a96419978a0022b7947b44d4a24a6ea99f00b6b485cbb6"
 dependencies = [
- "arrow",
+ "arrow 58.3.0",
  "async-trait",
  "bytes",
  "chrono",
@@ -1179,8 +1433,8 @@ version = "53.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ffa6c52cfed0734c5f93754d1c0175f558175248bf686c944fb05c373e5fc096"
 dependencies = [
- "arrow",
- "arrow-ipc",
+ "arrow 58.3.0",
+ "arrow-ipc 58.3.0",
  "async-trait",
  "bytes",
  "datafusion-common",
@@ -1203,7 +1457,7 @@ version = "53.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "503f29e0582c1fc189578d665ff57d9300da1f80c282777d7eb67bb79fb8cdca"
 dependencies = [
- "arrow",
+ "arrow 58.3.0",
  "async-trait",
  "bytes",
  "datafusion-common",
@@ -1226,7 +1480,7 @@ version = "53.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e33804749abc8d0c8cb7473228483cb8070e524c6f6086ee1b85a64debe2b3d2"
 dependencies = [
- "arrow",
+ "arrow 58.3.0",
  "async-trait",
  "bytes",
  "datafusion-common",
@@ -1256,11 +1510,11 @@ version = "53.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c03c7fbdaefcca4ef6ffe425a5fc2325763bfb426599bb0bf4536466efabe709"
 dependencies = [
- "arrow",
- "arrow-buffer",
+ "arrow 58.3.0",
+ "arrow-buffer 58.3.0",
  "async-trait",
  "chrono",
- "dashmap 6.1.0",
+ "dashmap 6.2.1",
  "datafusion-common",
  "datafusion-expr",
  "datafusion-physical-expr-common",
@@ -1279,7 +1533,7 @@ version = "53.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "574b9b6977fedbd2a611cbff12e5caf90f31640ad9dc5870f152836d94bad0dd"
 dependencies = [
- "arrow",
+ "arrow 58.3.0",
  "async-trait",
  "chrono",
  "datafusion-common",
@@ -1301,7 +1555,7 @@ version = "53.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d7c3adf3db8bf61e92eb90cb659c8e8b734593a8f7c8e12a843c7ddba24b87e"
 dependencies = [
- "arrow",
+ "arrow 58.3.0",
  "datafusion-common",
  "indexmap",
  "itertools",
@@ -1314,8 +1568,8 @@ version = "53.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f28aa4e10384e782774b10e72aca4d93ef7b31aa653095d9d4536b0a3dbc51b6"
 dependencies = [
- "arrow",
- "arrow-buffer",
+ "arrow 58.3.0",
+ "arrow-buffer 58.3.0",
  "base64",
  "chrono",
  "chrono-tz",
@@ -1343,7 +1597,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00aa6217e56098ba84e0a338176fe52f0a84cca398021512c6c8c5eff806d0ad"
 dependencies = [
  "ahash 0.8.12",
- "arrow",
+ "arrow 58.3.0",
  "datafusion-common",
  "datafusion-doc",
  "datafusion-execution",
@@ -1365,7 +1619,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b511250349407db7c43832ab2de63f5557b19a20dfd236b39ca2c04468b50d47"
 dependencies = [
  "ahash 0.8.12",
- "arrow",
+ "arrow 58.3.0",
  "datafusion-common",
  "datafusion-expr-common",
  "datafusion-physical-expr-common",
@@ -1377,8 +1631,8 @@ version = "53.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef13a858e20d50f0a9bb5e96e7ac82b4e7597f247515bccca4fdd2992df0212a"
 dependencies = [
- "arrow",
- "arrow-ord",
+ "arrow 58.3.0",
+ "arrow-ord 58.3.0",
  "datafusion-common",
  "datafusion-doc",
  "datafusion-execution",
@@ -1402,7 +1656,7 @@ version = "53.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b40d3f5bbb3905f9ccb1ce9485a9595c77b69758a7c24d3ba79e334ff51e7e"
 dependencies = [
- "arrow",
+ "arrow 58.3.0",
  "async-trait",
  "datafusion-catalog",
  "datafusion-common",
@@ -1418,7 +1672,7 @@ version = "53.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4e88ec9d57c9b685d02f58bfee7be62d72610430ddcedb82a08e5d9925dbfb6"
 dependencies = [
- "arrow",
+ "arrow 58.3.0",
  "datafusion-common",
  "datafusion-doc",
  "datafusion-expr",
@@ -1457,7 +1711,7 @@ version = "53.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e929015451a67f77d9d8b727b2bf3a40c4445fdef6cdc53281d7d97c76888ace"
 dependencies = [
- "arrow",
+ "arrow 58.3.0",
  "chrono",
  "datafusion-common",
  "datafusion-expr",
@@ -1477,7 +1731,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b1e68aba7a4b350401cfdf25a3d6f989ad898a7410164afe9ca52080244cb59"
 dependencies = [
  "ahash 0.8.12",
- "arrow",
+ "arrow 58.3.0",
  "datafusion-common",
  "datafusion-expr",
  "datafusion-expr-common",
@@ -1499,7 +1753,7 @@ version = "53.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea22315f33cf2e0adc104e8ec42e285f6ed93998d565c65e82fec6a9ee9f9db4"
 dependencies = [
- "arrow",
+ "arrow 58.3.0",
  "datafusion-common",
  "datafusion-expr",
  "datafusion-functions",
@@ -1515,7 +1769,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b04b45ea8ad3ac2d78f2ea2a76053e06591c9629c7a603eda16c10649ecf4362"
 dependencies = [
  "ahash 0.8.12",
- "arrow",
+ "arrow 58.3.0",
  "chrono",
  "datafusion-common",
  "datafusion-expr-common",
@@ -1531,7 +1785,7 @@ version = "53.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cb13397809a425918f608dfe8653f332015a3e330004ab191b4404187238b95"
 dependencies = [
- "arrow",
+ "arrow 58.3.0",
  "datafusion-common",
  "datafusion-execution",
  "datafusion-expr",
@@ -1550,9 +1804,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5edc023675791af9d5fb4cc4c24abf5f7bd3bd4dcf9e5bd90ea1eff6976dcc79"
 dependencies = [
  "ahash 0.8.12",
- "arrow",
- "arrow-ord",
- "arrow-schema",
+ "arrow 58.3.0",
+ "arrow-ord 58.3.0",
+ "arrow-schema 58.3.0",
  "async-trait",
  "datafusion-common",
  "datafusion-common-runtime",
@@ -1581,7 +1835,7 @@ version = "53.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac8c76860e355616555081cab5968cec1af7a80701ff374510860bcd567e365a"
 dependencies = [
- "arrow",
+ "arrow 58.3.0",
  "datafusion-common",
  "datafusion-datasource",
  "datafusion-expr-common",
@@ -1612,7 +1866,7 @@ version = "53.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa0d133ddf8b9b3b872acac900157f783e7b879fe9a6bccf389abebbfac45ec1"
 dependencies = [
- "arrow",
+ "arrow 58.3.0",
  "bigdecimal",
  "chrono",
  "datafusion-common",
@@ -1642,6 +1896,16 @@ dependencies = [
  "substrait",
  "tokio",
  "url",
+]
+
+[[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+dependencies = [
+ "powerfmt",
+ "serde_core",
 ]
 
 [[package]]
@@ -1714,7 +1978,7 @@ version = "1.10502.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fdc796383b176dd5a45353fbb5e64583c0ee4da12cb62c9e510b785324b2488"
 dependencies = [
- "arrow",
+ "arrow 58.3.0",
  "cast",
  "comfy-table",
  "fallible-iterator",
@@ -1726,6 +1990,12 @@ dependencies = [
  "rust_decimal",
  "strum",
 ]
+
+[[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "dyn-clone"
@@ -1746,6 +2016,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e079f19b08ca6239f47f8ba8509c11cf3ea30095831f7fed61441475edd8c449"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -1854,6 +2133,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
 name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1883,6 +2168,12 @@ dependencies = [
  "lazy_static",
  "num",
 ]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "funty"
@@ -1979,6 +2270,96 @@ dependencies = [
 ]
 
 [[package]]
+name = "gcloud-auth"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b43924e3df02cb3b846ca66a7ee58e8c13eb2556d0308c71f6154083f6980365"
+dependencies = [
+ "async-trait",
+ "base64",
+ "gcloud-metadata",
+ "home",
+ "jsonwebtoken",
+ "reqwest 0.13.3",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "time",
+ "token-source",
+ "tokio",
+ "tracing",
+ "urlencoding",
+]
+
+[[package]]
+name = "gcloud-bigquery"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5608493741763c0a874f00672110f040a24487ba1564e1a4e5af6f78a0b4c42b"
+dependencies = [
+ "anyhow",
+ "arrow 56.2.1",
+ "async-stream",
+ "async-trait",
+ "backon",
+ "base64",
+ "bigdecimal",
+ "gcloud-auth",
+ "gcloud-gax",
+ "gcloud-googleapis",
+ "num-bigint",
+ "prost-types",
+ "reqwest 0.13.3",
+ "reqwest-middleware",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "time",
+ "token-source",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "gcloud-gax"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "558634081d1cf458d1bc0166f69475a80f445b5b991f162028b293a38307059d"
+dependencies = [
+ "http",
+ "thiserror 2.0.18",
+ "token-source",
+ "tokio",
+ "tokio-retry2",
+ "tonic",
+ "tower",
+ "tracing",
+]
+
+[[package]]
+name = "gcloud-googleapis"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d79fc4ec36213a21b734a2ce204176eb39c439fa528f9a388c9a1349ca344b0d"
+dependencies = [
+ "prost",
+ "prost-types",
+ "tonic",
+ "tonic-prost",
+]
+
+[[package]]
+name = "gcloud-metadata"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd3152612316be627be52fe9ca72331eb48425059b3a6a700e7adde223e061d5"
+dependencies = [
+ "reqwest 0.13.3",
+ "thiserror 2.0.18",
+ "tokio",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2072,12 +2453,13 @@ dependencies = [
  "adbc_core",
  "adbc_datafusion",
  "adbc_driver_manager",
- "arrow",
+ "arrow 58.3.0",
  "bytes",
  "chrono",
  "const_format",
  "csscolorparser",
  "duckdb",
+ "gcloud-bigquery",
  "geozero",
  "jsonschema",
  "libloading",
@@ -2086,11 +2468,13 @@ dependencies = [
  "rand 0.8.6",
  "regex",
  "rusqlite",
+ "rustls",
  "serde",
  "serde_json",
  "sprintf",
  "tempfile",
  "thiserror 1.0.69",
+ "tokio",
  "toml_edit 0.22.27",
  "tree-sitter",
  "tree-sitter-ggsql",
@@ -2116,7 +2500,7 @@ name = "ggsql-jupyter"
 version = "0.3.2"
 dependencies = [
  "anyhow",
- "arrow",
+ "arrow 58.3.0",
  "bytes",
  "chrono",
  "clap",
@@ -2139,7 +2523,7 @@ dependencies = [
 name = "ggsql-wasm"
 version = "0.3.2"
 dependencies = [
- "arrow",
+ "arrow 58.3.0",
  "getrandom 0.2.17",
  "ggsql",
  "js-sys",
@@ -2156,6 +2540,25 @@ name = "glob"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
+name = "h2"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
 
 [[package]]
 name = "half"
@@ -2250,6 +2653,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "home"
+version = "0.5.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "http"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2304,6 +2716,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
+ "h2",
  "http",
  "http-body",
  "httparse",
@@ -2328,6 +2741,19 @@ dependencies = [
  "tokio-rustls",
  "tower-service",
  "webpki-roots",
+]
+
+[[package]]
+name = "hyper-timeout"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
+dependencies = [
+ "hyper",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
 ]
 
 [[package]]
@@ -2532,6 +2958,55 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys",
+ "log",
+ "simd_cesu8",
+ "thiserror 2.0.18",
+ "walkdir",
+ "windows-link",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "jobserver"
 version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2578,6 +3053,24 @@ dependencies = [
  "serde_json",
  "unicode-general-category",
  "uuid-simd",
+]
+
+[[package]]
+name = "jsonwebtoken"
+version = "10.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eba32bfb4ffdeaca3e34431072faf01745c9b26d25504aa7a6cf5684334fc4fc"
+dependencies = [
+ "aws-lc-rs",
+ "base64",
+ "getrandom 0.2.17",
+ "js-sys",
+ "pem",
+ "serde",
+ "serde_json",
+ "signature",
+ "simple_asn1",
+ "zeroize",
 ]
 
 [[package]]
@@ -2702,7 +3195,7 @@ dependencies = [
  "cc",
  "flate2",
  "pkg-config",
- "reqwest",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
  "tar",
@@ -2807,6 +3300,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "mime_guess"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
+dependencies = [
+ "mime",
+ "unicase",
+]
+
+[[package]]
 name = "minimad"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2892,6 +3401,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-conv"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+
+[[package]]
 name = "num-integer"
 version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2971,6 +3486,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
 name = "ordered-float"
 version = "2.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3038,12 +3559,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5dafa7d01085b62a47dd0c1829550a0a36710ea9c4fe358a05a85477cec8a908"
 dependencies = [
  "ahash 0.8.12",
- "arrow-array",
- "arrow-buffer",
- "arrow-data",
- "arrow-ipc",
- "arrow-schema",
- "arrow-select",
+ "arrow-array 58.3.0",
+ "arrow-buffer 58.3.0",
+ "arrow-data 58.3.0",
+ "arrow-ipc 58.3.0",
+ "arrow-schema 58.3.0",
+ "arrow-select 58.3.0",
  "base64",
  "bytes",
  "chrono",
@@ -3106,6 +3627,16 @@ dependencies = [
  "prost",
  "prost-build",
  "serde",
+]
+
+[[package]]
+name = "pem"
+version = "3.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
+dependencies = [
+ "base64",
+ "serde_core",
 ]
 
 [[package]]
@@ -3190,6 +3721,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "pin-project"
+version = "1.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2466b2336ed02bcdca6b294417127b90ec92038d1d5c4fbeac971a922e0e0924"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3209,6 +3760,12 @@ checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
  "zerovec",
 ]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
@@ -3344,6 +3901,7 @@ version = "0.11.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
 dependencies = [
+ "aws-lc-rs",
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
@@ -3592,6 +4150,65 @@ dependencies = [
 ]
 
 [[package]]
+name = "reqwest"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62e0021ea2c22aed41653bc7e1419abb2c97e038ff2c33d0e1309e49a97deec0"
+dependencies = [
+ "base64",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "mime",
+ "mime_guess",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "rustls-platform-verifier",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tokio-util",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-streams",
+ "web-sys",
+]
+
+[[package]]
+name = "reqwest-middleware"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "199dda04a536b532d0cc04d7979e39b1c763ea749bf91507017069c00b96056f"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "http",
+ "reqwest 0.13.3",
+ "serde",
+ "thiserror 2.0.18",
+ "tower-service",
+]
+
+[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3601,7 +4218,7 @@ dependencies = [
  "cfg-if",
  "getrandom 0.2.17",
  "libc",
- "untrusted",
+ "untrusted 0.9.0",
  "windows-sys 0.52.0",
 ]
 
@@ -3724,6 +4341,7 @@ version = "0.23.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
+ "aws-lc-rs",
  "log",
  "once_cell",
  "ring",
@@ -3731,6 +4349,18 @@ dependencies = [
  "rustls-webpki",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
 ]
 
 [[package]]
@@ -3744,14 +4374,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-platform-verifier"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
+dependencies = [
+ "core-foundation",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
+
+[[package]]
 name = "rustls-webpki"
 version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
- "untrusted",
+ "untrusted 0.9.0",
 ]
 
 [[package]]
@@ -3773,6 +4431,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3816,6 +4483,29 @@ name = "seahash"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "semver"
@@ -3992,16 +4682,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "rand_core 0.6.4",
+]
+
+[[package]]
 name = "simd-adler32"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
+name = "simd_cesu8"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
 name = "simdutf8"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
+name = "simple_asn1"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d585997b0ac10be3c5ee635f1bab02d512760d14b7c468801ac8a01d9ae5f1d"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "thiserror 2.0.18",
+ "time",
+]
 
 [[package]]
 name = "siphasher"
@@ -4304,6 +5025,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "time"
+version = "0.3.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+dependencies = [
+ "deranged",
+ "itoa",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+
+[[package]]
+name = "time-macros"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
+
+[[package]]
 name = "tiny-keccak"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4338,6 +5090,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
+name = "token-source"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75746ae15bef509f21039a652383104424208fdae172a964a8930858b9a78412"
+dependencies = [
+ "async-trait",
+]
+
+[[package]]
 name = "tokio"
 version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4363,6 +5124,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "tokio-retry2"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e05e40fd65880de11383bbc693d3c636045ed1b5010ef1265a1d2b41d73334a1"
+dependencies = [
+ "pin-project",
+ "tokio",
 ]
 
 [[package]]
@@ -4411,7 +5182,7 @@ dependencies = [
  "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
  "toml_writer",
- "winnow 1.0.2",
+ "winnow 1.0.3",
 ]
 
 [[package]]
@@ -4450,7 +5221,7 @@ dependencies = [
  "indexmap",
  "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
- "winnow 1.0.2",
+ "winnow 1.0.3",
 ]
 
 [[package]]
@@ -4459,7 +5230,7 @@ version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow 1.0.2",
+ "winnow 1.0.3",
 ]
 
 [[package]]
@@ -4475,6 +5246,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
+name = "tonic"
+version = "0.14.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac2a5518c70fa84342385732db33fb3f44bc4cc748936eb5833d2df34d6445ef"
+dependencies = [
+ "async-trait",
+ "base64",
+ "bytes",
+ "flate2",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-timeout",
+ "hyper-util",
+ "percent-encoding",
+ "pin-project",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tokio-stream",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+ "webpki-roots",
+]
+
+[[package]]
+name = "tonic-prost"
+version = "0.14.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50849f68853be452acf590cde0b146665b8d507b3b8af17261df47e02c209ea0"
+dependencies = [
+ "bytes",
+ "prost",
+ "tonic",
+]
+
+[[package]]
 name = "tower"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4482,11 +5293,15 @@ checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
 dependencies = [
  "futures-core",
  "futures-util",
+ "indexmap",
  "pin-project-lite",
+ "slab",
  "sync_wrapper",
  "tokio",
+ "tokio-util",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -4683,6 +5498,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicase"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
+
+[[package]]
 name = "unicode-general-category"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4723,6 +5544,12 @@ name = "unsafe-libyaml"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
+
+[[package]]
+name = "untrusted"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "untrusted"
@@ -4770,6 +5597,12 @@ dependencies = [
  "percent-encoding",
  "serde",
 ]
+
+[[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "utf8-zero"
@@ -4956,6 +5789,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-streams"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1ec4f6517c9e11ae630e200b2b65d193279042e28edd4a2cda233e46670bbb"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
 name = "wasmparser"
 version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4985,6 +5831,15 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-root-certs"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -5273,9 +6128,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
+checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
 dependencies = [
  "memchr",
 ]
@@ -5480,6 +6335,20 @@ name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "zeromq"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ duckdb = { version = "~1.10502", features = ["bundled", "vtab-arrow"] }
 parquet = { version = "58", default-features = false, features = ["arrow", "snap"] }
 bytes = "1"
 rusqlite = { version = "0.38", features = ["bundled", "chrono"] }
+gcloud-bigquery = "1.6"
 
 # ODBC
 toml_edit = "0.22"

--- a/doc/get_started/tooling/cli.qmd
+++ b/doc/get_started/tooling/cli.qmd
@@ -49,6 +49,13 @@ $ ggsql validate "VISUALISE x, y FROM table DRAW point"
 
 Both `ggsql exec` and `ggsql run` accept a `--reader` flag that can be used to specify a connection string to be used when executing the query. If not provided, ggsql will use an empty in-memory duckdb connection, equivalent to `--reader duckdb://memory`.
 
+To connect to Google BigQuery, use `bigquery://PROJECT_ID` and authenticate first with [Application Default Credentials](https://cloud.google.com/docs/authentication/application-default-credentials):
+
+```bash
+gcloud auth application-default login
+ggsql run my_query.ggsql --reader bigquery://my-gcp-project
+```
+
 ```bash
 $ ggsql exec --reader sqlite://sample/ggsql_test.sqlite \
   "SELECT * FROM test_table LIMIT 3"

--- a/ggsql-cli/Cargo.toml
+++ b/ggsql-cli/Cargo.toml
@@ -41,9 +41,10 @@ duckdb = ["ggsql/duckdb"]
 parquet = ["ggsql/parquet"]
 sqlite = ["ggsql/sqlite"]
 odbc = ["ggsql/odbc"]
+bigquery = ["ggsql/bigquery"]
 vegalite = ["ggsql/vegalite"]
 builtin-data = ["ggsql/builtin-data"]
-all-readers = ["duckdb", "sqlite", "odbc"]
+all-readers = ["duckdb", "sqlite", "odbc", "bigquery"]
 
 # cargo-packager configuration for cross-platform installers
 [package.metadata.packager]

--- a/ggsql-cli/src/main.rs
+++ b/ggsql-cli/src/main.rs
@@ -34,7 +34,7 @@ pub enum Commands {
         /// The ggsql query to execute
         query: String,
 
-        /// Data source connection string (duckdb://, sqlite://, odbc://)
+        /// Data source connection string (duckdb://, sqlite://, odbc://, bigquery://)
         #[arg(long, default_value = "duckdb://memory")]
         reader: String,
 
@@ -56,7 +56,7 @@ pub enum Commands {
         /// Path to .sql file containing ggsql query
         file: PathBuf,
 
-        /// Data source connection string (duckdb://, sqlite://, odbc://)
+        /// Data source connection string (duckdb://, sqlite://, odbc://, bigquery://)
         #[arg(long, default_value = "duckdb://memory")]
         reader: String,
 
@@ -88,7 +88,7 @@ pub enum Commands {
         /// The ggsql query to validate
         query: String,
 
-        /// Data source connection string for column validation (duckdb://, sqlite://, polars://)
+        /// Data source connection string for column validation (duckdb://, sqlite://, odbc://, bigquery://)
         #[arg(long)]
         reader: Option<String>,
     },
@@ -254,6 +254,23 @@ fn cmd_exec(query: String, reader: String, writer: String, output: Option<PathBu
         #[cfg(not(feature = "odbc"))]
         {
             eprintln!("ODBC reader not compiled in. Rebuild with --features odbc");
+            std::process::exit(1);
+        }
+    } else if reader.starts_with("bigquery://") {
+        #[cfg(feature = "bigquery")]
+        {
+            let r = match ggsql::reader::BigQueryReader::from_connection_string(&reader) {
+                Ok(r) => r,
+                Err(e) => {
+                    eprintln!("Failed to create reader: {}", e);
+                    std::process::exit(1);
+                }
+            };
+            exec_with_reader(&query, &r, &writer, output, verbose);
+        }
+        #[cfg(not(feature = "bigquery"))]
+        {
+            eprintln!("BigQuery reader not compiled in. Rebuild with --features bigquery");
             std::process::exit(1);
         }
     } else if reader.starts_with("postgres://") || reader.starts_with("postgresql://") {

--- a/ggsql-jupyter/Cargo.toml
+++ b/ggsql-jupyter/Cargo.toml
@@ -57,11 +57,12 @@ hex = "0.4"
 uuid = { version = "1.0", features = ["v4"] }
 
 [features]
-default = ["all-readers"]
-all-readers = ["sqlite", "odbc", "duckdb"]
+default = ["sqlite", "odbc", "duckdb"]
+all-readers = ["sqlite", "odbc", "duckdb", "bigquery"]
 odbc = ["ggsql/odbc"]
 sqlite = ["ggsql/sqlite"]
 duckdb = ["ggsql/duckdb"]
+bigquery = ["ggsql/bigquery"]
 
 [dev-dependencies]
 tempfile = "3.8"

--- a/ggsql-jupyter/src/executor.rs
+++ b/ggsql-jupyter/src/executor.rs
@@ -34,6 +34,7 @@ pub enum ExecutionResult {
 /// - `duckdb://memory` or `duckdb://<path>` (always available)
 /// - `sqlite://<path>` (requires `sqlite` feature)
 /// - `odbc://...` (requires `odbc` feature)
+/// - `bigquery://project[/dataset][?location=US]` (requires `bigquery` feature)
 pub fn create_reader(uri: &str) -> Result<Box<dyn Reader + Send>> {
     use ggsql::reader::connection::ConnectionInfo;
 
@@ -57,6 +58,11 @@ pub fn create_reader(uri: &str) -> Result<Box<dyn Reader + Send>> {
         ConnectionInfo::SQLite(path) => {
             let reader =
                 ggsql::reader::SqliteReader::from_connection_string(&format!("sqlite://{}", path))?;
+            Ok(Box::new(reader))
+        }
+        #[cfg(feature = "bigquery")]
+        ConnectionInfo::BigQuery(_) => {
+            let reader = ggsql::reader::BigQueryReader::from_connection_string(uri)?;
             Ok(Box::new(reader))
         }
         _ => anyhow::bail!("Unsupported reader type for connection string: {}", uri),
@@ -86,6 +92,10 @@ pub fn display_name_for_uri(uri: &str) -> String {
         }
         return "ODBC".to_string();
     }
+    if let Some(rest) = uri.strip_prefix("bigquery://") {
+        let path = rest.split('?').next().unwrap_or(rest);
+        return format!("BigQuery ({})", path);
+    }
     uri.to_string()
 }
 
@@ -109,6 +119,9 @@ pub fn type_name_for_uri(uri: &str) -> String {
         }
         return "ODBC".to_string();
     }
+    if uri.starts_with("bigquery://") {
+        return "BigQuery".to_string();
+    }
     "Unknown".to_string()
 }
 
@@ -130,6 +143,9 @@ pub fn host_for_uri(uri: &str) -> String {
         if let Some(server) = extract_odbc_value(odbc, "server") {
             return server;
         }
+    }
+    if let Some(rest) = uri.strip_prefix("bigquery://") {
+        return rest.split('?').next().unwrap_or(rest).to_string();
     }
     uri.to_string()
 }
@@ -300,6 +316,10 @@ mod tests {
         assert_eq!(display_name_for_uri("duckdb://my.db"), "DuckDB (my.db)");
         assert_eq!(display_name_for_uri("sqlite://:memory:"), "SQLite (memory)");
         assert_eq!(display_name_for_uri("sqlite://data.db"), "SQLite (data.db)");
+        assert_eq!(
+            display_name_for_uri("bigquery://my-project/analytics?location=US"),
+            "BigQuery (my-project/analytics)"
+        );
         assert_eq!(
             display_name_for_uri("odbc://DSN=my-postgres"),
             "my-postgres (ODBC)"

--- a/ggsql-vscode/src/connections.ts
+++ b/ggsql-vscode/src/connections.ts
@@ -29,6 +29,7 @@ export function createConnectionDrivers(
         createSnowflakeSSODriver(positronApi),
         createSnowflakePATDriver(positronApi),
         createOdbcDriver(positronApi),
+        createBigQueryNativeDriver(positronApi),
     ];
 }
 
@@ -446,3 +447,43 @@ function createOdbcDriver(
         },
     };
 }
+
+// ============================================================================
+// BigQuery
+// ============================================================================
+
+/**
+ * Native BigQuery connection driver.
+ *
+ * Uses Application Default Credentials in the ggsql kernel process.
+ */
+function createBigQueryNativeDriver(
+    positronApi: PositronApi
+): positron.ConnectionsDriver {
+    return {
+        driverId: 'ggsql-bigquery-native',
+        metadata: {
+            languageId: 'ggsql',
+            name: 'BigQuery',
+            description: 'Native',
+            inputs: [
+                { id: 'project', label: 'Project', type: 'string' },
+                { id: 'dataset', label: 'Dataset', type: 'string', value: '' },
+                { id: 'location', label: 'Location', type: 'string', value: 'US' },
+            ],
+        } as ConnectionsDriverMetadata,
+        generateCode: (inputs) => {
+            const get = (id: string) =>
+                inputs.find((i) => i.id === id)?.value?.trim() || '';
+            const project = get('project');
+            const dataset = get('dataset');
+            const location = get('location') || 'US';
+            const path = dataset ? `${project}/${dataset}` : project;
+            return `-- @connect: bigquery://${path}?location=${encodeURIComponent(location)}`;
+        },
+        connect: async (code: string) => {
+            await positronApi.runtime.executeCode('ggsql', code, false);
+        },
+    };
+}
+

--- a/src/Cargo.toml
+++ b/src/Cargo.toml
@@ -29,6 +29,7 @@ duckdb = { workspace = true, optional = true }
 rusqlite = { workspace = true, optional = true }
 toml_edit = { workspace = true, optional = true }
 libloading = { workspace = true, optional = true }
+gcloud-bigquery = { workspace = true, optional = true }
 parquet = { workspace = true, optional = true }
 bytes = { workspace = true }
 
@@ -45,6 +46,9 @@ serde_json.workspace = true
 # Error handling
 thiserror.workspace = true
 
+# Async runtime (used by gcloud-bigquery)
+tokio = { workspace = true, optional = true, features = ["rt-multi-thread"] }
+
 # Utilities
 regex.workspace = true
 chrono.workspace = true
@@ -59,6 +63,7 @@ tempfile = "3.8"
 ureq = "3"
 adbc_datafusion = "0.23"
 adbc_driver_manager = "0.23"
+rustls = { version = "0.23", default-features = false, features = ["ring"] }
 
 [features]
 default = ["adbc", "duckdb", "sqlite", "vegalite", "parquet", "builtin-data", "odbc", "spatial"]
@@ -68,6 +73,7 @@ sqlite = ["dep:rusqlite"]
 adbc = ["dep:adbc_core"]
 odbc = ["dep:toml_edit", "dep:libloading"]
 spatial = ["dep:geozero"]
+bigquery = ["dep:gcloud-bigquery", "dep:tokio"]
 vegalite = []
 builtin-data = []
-all-readers = ["duckdb", "sqlite", "odbc"]
+all-readers = ["duckdb", "sqlite", "odbc", "bigquery"]

--- a/src/execute/mod.rs
+++ b/src/execute/mod.rs
@@ -1135,7 +1135,7 @@ pub fn prepare_data_with_reader(query: &str, reader: &dyn Reader) -> Result<Prep
     // Extract CTE definitions from the source tree (in declaration order)
     let ctes = cte::extract_ctes(&source_tree);
 
-    // Materialize CTEs as registered tables via reader.register()
+    // Materialize CTEs as temp tables via the dialect's create_or_replace_temp_table_sql
     let materialized_ctes = cte::materialize_ctes(&ctes, reader)?;
 
     // Build data map for multi-source support

--- a/src/plot/layer/geom/histogram.rs
+++ b/src/plot/layer/geom/histogram.rs
@@ -190,18 +190,6 @@ fn stat_histogram(
             min = min_val
         )
     };
-    // Build the bin end expression (bin start + bin width)
-    let bin_end_expr = format!("{expr} + {w}", expr = bin_expr, w = bin_width);
-
-    // Build grouped columns (group_by includes partition_by + facet variables)
-    let group_cols = if group_by.is_empty() {
-        bin_expr.clone()
-    } else {
-        let mut cols: Vec<String> = group_by.to_vec();
-        cols.push(bin_expr.clone());
-        cols.join(", ")
-    };
-
     // Determine aggregation expression based on weight aesthetic
     let agg_expr = if let Some(weight_value) = aesthetics.get("weight") {
         if weight_value.is_literal() {
@@ -218,9 +206,8 @@ fn stat_histogram(
         "COUNT(*)".to_string()
     };
 
-    // Use semantically meaningful column names with prefix to avoid conflicts
-    // Include bin (start), bin_end (end), count/sum, and density
-    // Use a two-stage query: first GROUP BY, then calculate density with window function
+    // Stat output columns, prefixed to avoid clashing with user columns:
+    // bin (start), bin_end (end), count/sum, density.
     let stat_bin = naming::stat_column("bin");
     let stat_bin_end = naming::stat_column("bin_end");
     let stat_count = naming::stat_column("count");
@@ -230,40 +217,46 @@ fn stat_histogram(
     let q_bin_end = naming::quote_ident(&stat_bin_end);
     let q_count = naming::quote_ident(&stat_count);
     let q_density = naming::quote_ident(&stat_density);
-    let (binned_select, final_select) = if group_by.is_empty() {
+
+    // Two-stage query. `__binned__` groups rows by the bin expression and counts
+    // them; its only non-facet grouping key is `bin_expr`. The outer SELECT then
+    // derives bin_end (bin + width) and density from the already-grouped `bin`
+    // and `count` columns. Computing the derived columns outside the GROUP BY
+    // query keeps every grouped SELECT expression equal to a grouping key, which
+    // strict dialects (e.g. BigQuery) require.
+    let (group_cols, binned_select, density_window) = if group_by.is_empty() {
         (
-            format!(
-                "{} AS {}, {} AS {}, {} AS {}",
-                bin_expr, q_bin, bin_end_expr, q_bin_end, agg_expr, q_count
-            ),
-            format!(
-                "*, {count} * 1.0 / SUM({count}) OVER () AS {density}",
-                count = q_count,
-                density = q_density
-            ),
+            bin_expr.clone(),
+            format!("{} AS {}, {} AS {}", bin_expr, q_bin, agg_expr, q_count),
+            "OVER ()".to_string(),
         )
     } else {
         let grp_cols = group_by.join(", ");
         (
+            format!("{}, {}", grp_cols, bin_expr),
             format!(
-                "{}, {} AS {}, {} AS {}, {} AS {}",
-                grp_cols, bin_expr, q_bin, bin_end_expr, q_bin_end, agg_expr, q_count
+                "{}, {} AS {}, {} AS {}",
+                grp_cols, bin_expr, q_bin, agg_expr, q_count
             ),
-            format!(
-                "*, {count} * 1.0 / SUM({count}) OVER (PARTITION BY {grp}) AS {density}",
-                count = q_count,
-                grp = grp_cols,
-                density = q_density
-            ),
+            format!("OVER (PARTITION BY {})", grp_cols),
         )
     };
 
     let transformed_query = format!(
-        "WITH \"__stat_src__\" AS ({query}), \"__binned__\" AS (SELECT {binned} FROM \"__stat_src__\" GROUP BY {group}) SELECT {final} FROM \"__binned__\"",
+        "WITH \"__stat_src__\" AS ({query}), \
+         \"__binned__\" AS (SELECT {binned} FROM \"__stat_src__\" GROUP BY {group}) \
+         SELECT *, {bin} + {width} AS {bin_end}, \
+         {count} * 1.0 / SUM({count}) {density_window} AS {density} \
+         FROM \"__binned__\"",
         query = query,
         binned = binned_select,
         group = group_cols,
-        final = final_select
+        bin = q_bin,
+        width = bin_width,
+        bin_end = q_bin_end,
+        count = q_count,
+        density_window = density_window,
+        density = q_density,
     );
 
     // Histogram always transforms - produces bin, bin_end, count, and density columns

--- a/src/reader/bigquery.rs
+++ b/src/reader/bigquery.rs
@@ -694,12 +694,20 @@ mod tests {
 
     use std::sync::OnceLock;
 
-    /// RAII fixture: creates a uniquely-named dataset + table, drops both on drop.
-    /// Stored in a static so all integration tests share the same infra.
+    /// RAII fixture: creates a uniquely-named dataset and a few tables, drops
+    /// the whole dataset on drop. Stored in a static so all integration tests
+    /// share the same infra.
+    ///
+    /// Tables:
+    /// - `readings` — 3 rows of id/label/value/flag, for the listing and DRAW tests.
+    /// - `types`    — DATE/TIMESTAMP/DATETIME/TIME/NUMERIC columns, for conversion.
+    /// - `wide`     — 25_000 rows, for result pagination (PAGE_SIZE is 10_000).
     struct BqTestFixture {
         project_id: String,
         dataset_id: String,
         table_id: String,
+        types_table: String,
+        wide_table: String,
     }
 
     impl BqTestFixture {
@@ -710,6 +718,8 @@ mod tests {
 
             let dataset_id = format!("ggsql_test_{}", uuid::Uuid::new_v4().simple());
             let table_id = "readings".to_string();
+            let types_table = "types".to_string();
+            let wide_table = "wide".to_string();
 
             let bootstrap = BigQueryReader::from_connection_string(base_uri)?;
             let project_id = bootstrap.project_id().to_string();
@@ -725,8 +735,33 @@ mod tests {
                     SELECT 3,       'gamma',           3.5,          TRUE",
                 project_id, dataset_id, table_id
             ))?;
+            // One populated row and one all-NULL row, so the conversion exercises
+            // both the value and the null path for every type.
+            bootstrap.execute_sql(&format!(
+                "CREATE TABLE `{}.{}.{}` AS
+                    SELECT DATE '2026-05-21' AS d, \
+                           TIMESTAMP '2026-05-21 12:00:00 UTC' AS ts, \
+                           DATETIME '2026-05-21 12:00:00' AS dt, \
+                           TIME '12:00:00' AS t, \
+                           NUMERIC '123.45' AS n UNION ALL
+                    SELECT CAST(NULL AS DATE), CAST(NULL AS TIMESTAMP), \
+                           CAST(NULL AS DATETIME), CAST(NULL AS TIME), \
+                           CAST(NULL AS NUMERIC)",
+                project_id, dataset_id, types_table
+            ))?;
+            bootstrap.execute_sql(&format!(
+                "CREATE TABLE `{}.{}.{}` AS \
+                 SELECT n FROM UNNEST(GENERATE_ARRAY(1, 25000)) AS n",
+                project_id, dataset_id, wide_table
+            ))?;
 
-            Ok(Self { project_id, dataset_id, table_id })
+            Ok(Self {
+                project_id,
+                dataset_id,
+                table_id,
+                types_table,
+                wide_table,
+            })
         }
 
         /// Build a reader whose default dataset points at this fixture's dataset.
@@ -883,5 +918,55 @@ mod tests {
             ))
             .unwrap();
         assert!(spec.metadata().rows > 0, "histogram returned no rows");
+    }
+
+    #[test]
+    #[ignore = "touches live BigQuery infra; set GGSQL_BIGQUERY_TEST_URI=bigquery://project and run with --ignored"]
+    fn bq_integration_type_conversion() {
+        use arrow::datatypes::TimeUnit;
+
+        let f = integration_fixture();
+        let reader = f.reader().unwrap();
+        let df = reader
+            .execute_sql(&format!("SELECT d, ts, dt, t, n FROM `{}`", f.types_table))
+            .unwrap();
+        assert_eq!(df.shape(), (2, 5));
+        assert_eq!(df.column_dtype("d").unwrap(), DataType::Date32);
+        assert_eq!(
+            df.column_dtype("ts").unwrap(),
+            DataType::Timestamp(TimeUnit::Microsecond, None)
+        );
+        assert_eq!(
+            df.column_dtype("dt").unwrap(),
+            DataType::Timestamp(TimeUnit::Microsecond, None)
+        );
+        assert_eq!(
+            df.column_dtype("t").unwrap(),
+            DataType::Time64(TimeUnit::Nanosecond)
+        );
+        assert_eq!(df.column_dtype("n").unwrap(), DataType::Float64);
+    }
+
+    #[test]
+    #[ignore = "touches live BigQuery infra; set GGSQL_BIGQUERY_TEST_URI=bigquery://project and run with --ignored"]
+    fn bq_integration_pagination() {
+        // PAGE_SIZE is 10_000, so a 25_000-row scan must stitch three result
+        // pages. A wrong row count means a page was dropped or duplicated.
+        let f = integration_fixture();
+        let reader = f.reader().unwrap();
+        let df = reader
+            .execute_sql(&format!("SELECT n FROM `{}`", f.wide_table))
+            .unwrap();
+        assert_eq!(df.shape(), (25_000, 1));
+    }
+
+    #[test]
+    #[ignore = "touches live BigQuery infra; set GGSQL_BIGQUERY_TEST_URI=bigquery://project and run with --ignored"]
+    fn bq_integration_query_error() {
+        // A failing query must surface as an Err, not a panic.
+        let f = integration_fixture();
+        let reader = f.reader().unwrap();
+        let result = reader.execute_sql("SELECT * FROM `__ggsql_no_such_table__`");
+        assert!(result.is_err(), "expected an error for a missing table");
     }
 }

--- a/src/reader/bigquery.rs
+++ b/src/reader/bigquery.rs
@@ -1,0 +1,887 @@
+//! Google BigQuery support.
+//!
+//! - `BigQueryDialect` — SQL dialect for BigQuery-specific syntax and type names,
+//!   used by `BigQueryReader`.
+//! - `BigQueryReader` — native reader via Application Default Credentials,
+//!   behind the `bigquery` feature flag.
+
+use crate::{DataFrame, GgsqlError, Result};
+use arrow::array::*;
+use chrono::{Datelike, Timelike};
+use gcloud_bigquery::client::{Client, ClientConfig};
+use gcloud_bigquery::http::dataset::DatasetReference;
+use gcloud_bigquery::http::job::get_query_results::GetQueryResultsRequest;
+use gcloud_bigquery::http::job::query::{QueryRequest, QueryResponse};
+use gcloud_bigquery::http::table::{TableFieldSchema, TableFieldType, TableSchema};
+use gcloud_bigquery::http::tabledata::list::{Tuple, Value};
+use gcloud_bigquery::http::types::ConnectionProperty;
+use std::cell::RefCell;
+use std::sync::Arc;
+use tokio::runtime::Runtime;
+
+const DEFAULT_LOCATION: &str = "US";
+const PAGE_SIZE: i64 = 10_000;
+
+// ============================================================================
+// Dialect
+// ============================================================================
+
+/// BigQuery SQL dialect.
+pub struct BigQueryDialect;
+
+impl super::SqlDialect for BigQueryDialect {
+    fn number_type_name(&self) -> Option<&str> {
+        Some("FLOAT64")
+    }
+
+    fn integer_type_name(&self) -> Option<&str> {
+        Some("INT64")
+    }
+
+    fn datetime_type_name(&self) -> Option<&str> {
+        Some("DATETIME")
+    }
+
+    fn string_type_name(&self) -> Option<&str> {
+        Some("STRING")
+    }
+
+    fn sql_greatest(&self, exprs: &[&str]) -> String {
+        if exprs.len() == 1 {
+            return exprs[0].to_string();
+        }
+        format!("GREATEST({})", exprs.join(", "))
+    }
+
+    fn sql_least(&self, exprs: &[&str]) -> String {
+        if exprs.len() == 1 {
+            return exprs[0].to_string();
+        }
+        format!("LEAST({})", exprs.join(", "))
+    }
+
+    fn sql_generate_series(&self, n: usize) -> String {
+        format!(
+            "`__ggsql_seq__`(n) AS (SELECT CAST(n AS FLOAT64) AS n FROM UNNEST(GENERATE_ARRAY(0, {})) AS n)",
+            n - 1
+        )
+    }
+
+    fn sql_quantile_inline(&self, column: &str, fraction: f64) -> Option<String> {
+        // APPROX_QUANTILES splits the column into 100 buckets; OFFSET(N) picks
+        // the Nth percentile boundary. Unlike PERCENTILE_CONT (a window-only
+        // function), it is a genuine aggregate, so it composes directly inside a
+        // GROUP BY query — no correlated subquery, which BigQuery rejects.
+        let offset = (fraction * 100.0).round() as i64;
+        Some(format!(
+            "APPROX_QUANTILES({}, 100)[OFFSET({})]",
+            quote_ident(column),
+            offset
+        ))
+    }
+
+    fn sql_percentile(
+        &self,
+        column: &str,
+        fraction: f64,
+        _from: &str,
+        _groups: &[String],
+    ) -> String {
+        // BigQuery has no exact percentile *aggregate* and rejects the correlated
+        // scalar-subquery form of the portable default. Every caller (boxplot,
+        // density) embeds the result in the SELECT list of a GROUP BY query,
+        // where the APPROX_QUANTILES aggregate computes per group — so `from`
+        // and `groups` are not needed here.
+        self.sql_quantile_inline(column, fraction)
+            .expect("BigQuery sql_quantile_inline always returns Some")
+    }
+
+    fn sql_date_literal(&self, days_since_epoch: i32) -> String {
+        format!("DATE_ADD(DATE '1970-01-01', INTERVAL {} DAY)", days_since_epoch)
+    }
+
+    fn sql_datetime_literal(&self, microseconds_since_epoch: i64) -> String {
+        format!("DATETIME(TIMESTAMP_MICROS({}))", microseconds_since_epoch)
+    }
+
+    fn sql_time_literal(&self, nanoseconds_since_midnight: i64) -> String {
+        let microseconds = nanoseconds_since_midnight / 1_000;
+        format!("TIME(TIMESTAMP_MICROS({}))", microseconds)
+    }
+
+    fn create_or_replace_temp_table_sql(
+        &self,
+        name: &str,
+        column_aliases: &[String],
+        body_sql: &str,
+    ) -> Vec<String> {
+        let body = if column_aliases.is_empty() {
+            body_sql.to_string()
+        } else {
+            let cols = column_aliases
+                .iter()
+                .map(|c| quote_ident(c))
+                .collect::<Vec<_>>()
+                .join(", ");
+            format!(
+                "WITH __ggsql_aliased__({}) AS ({}) SELECT * FROM __ggsql_aliased__",
+                cols, body_sql
+            )
+        };
+        vec![format!(
+            "CREATE OR REPLACE TEMP TABLE {} AS {}",
+            quote_ident(name),
+            body
+        )]
+    }
+}
+
+impl BigQueryDialect {
+    pub(crate) fn sql_list_catalogs() -> String {
+        "SELECT @@project_id AS catalog_name".to_string()
+    }
+
+    pub(crate) fn sql_list_schemas(catalog: &str) -> String {
+        format!(
+            "SELECT schema_name FROM {}.INFORMATION_SCHEMA.SCHEMATA ORDER BY schema_name",
+            quote_path(&[catalog])
+        )
+    }
+
+    pub(crate) fn sql_list_tables(catalog: &str, schema: &str) -> String {
+        format!(
+            "SELECT table_name, table_type FROM {}.INFORMATION_SCHEMA.TABLES ORDER BY table_name",
+            quote_path(&[catalog, schema])
+        )
+    }
+
+    pub(crate) fn sql_list_columns(catalog: &str, schema: &str, table: &str) -> String {
+        format!(
+            "SELECT column_name, data_type FROM {}.INFORMATION_SCHEMA.COLUMNS \
+             WHERE table_name = '{}' ORDER BY ordinal_position",
+            quote_path(&[catalog, schema]),
+            table.replace('\'', "''")
+        )
+    }
+}
+
+fn quote_ident(name: &str) -> String {
+    format!("`{}`", name.replace('`', "``"))
+}
+
+fn quote_path(parts: &[&str]) -> String {
+    quote_ident(&parts.join("."))
+}
+
+// ============================================================================
+// Reader
+// ============================================================================
+
+/// Native BigQuery reader using Application Default Credentials.
+pub struct BigQueryReader {
+    runtime: Runtime,
+    client: Client,
+    project_id: String,
+    default_dataset: Option<String>,
+    location: String,
+    session_id: RefCell<Option<String>>,
+}
+
+// The reader owns a single BigQuery session id and mutates it through
+// interior mutability; use it from one thread at a time like the ODBC reader.
+unsafe impl Send for BigQueryReader {}
+
+impl BigQueryReader {
+    pub fn from_connection_string(uri: &str) -> Result<Self> {
+        let info = match super::connection::parse_connection_string(uri)? {
+            super::connection::ConnectionInfo::BigQuery(info) => info,
+            _ => {
+                return Err(GgsqlError::ReaderError(format!(
+                    "Connection string '{}' is not supported by BigQueryReader",
+                    uri
+                )))
+            }
+        };
+
+        let runtime = Runtime::new().map_err(|e| {
+            GgsqlError::ReaderError(format!("Failed to create BigQuery runtime: {}", e))
+        })?;
+
+        let (client, detected_project) = runtime.block_on(async {
+            let (config, detected_project) =
+                ClientConfig::new_with_auth().await.map_err(|e| {
+                    GgsqlError::ReaderError(format!(
+                        "Failed to initialize BigQuery authentication: {}",
+                        e
+                    ))
+                })?;
+            let client = Client::new(config).await.map_err(|e| {
+                GgsqlError::ReaderError(format!("Failed to create BigQuery client: {}", e))
+            })?;
+            Ok::<_, GgsqlError>((client, detected_project))
+        })?;
+
+        let project_id = match info.project_id {
+            Some(id) => id,
+            None => detected_project.ok_or_else(|| {
+                GgsqlError::ReaderError(
+                    "No BigQuery project specified in the URI and ADC did not provide one. \
+                     Set GOOGLE_CLOUD_PROJECT or run `gcloud config set project <id>`."
+                        .to_string(),
+                )
+            })?,
+        };
+
+        Ok(Self {
+            runtime,
+            client,
+            project_id,
+            default_dataset: info.default_dataset,
+            location: info.location.unwrap_or_else(|| DEFAULT_LOCATION.to_string()),
+            session_id: RefCell::new(None),
+        })
+    }
+
+    pub fn project_id(&self) -> &str {
+        &self.project_id
+    }
+
+    async fn run_query(&self, sql: &str) -> Result<QueryResponse> {
+        let response = self
+            .client
+            .job()
+            .query(&self.project_id, &self.query_request(sql))
+            .await
+            .map_err(|e| GgsqlError::ReaderError(format!("BigQuery query failed: {}", e)))?;
+
+        if let Some(errors) = &response.errors {
+            if !errors.is_empty() {
+                return Err(GgsqlError::ReaderError(format!(
+                    "BigQuery query failed: {:?}",
+                    errors
+                )));
+            }
+        }
+
+        if self.session_id.borrow().is_none() {
+            if let Some(session_id) = response
+                .session_info
+                .as_ref()
+                .and_then(|info| info.session_id.clone())
+            {
+                *self.session_id.borrow_mut() = Some(session_id);
+            }
+        }
+
+        Ok(response)
+    }
+
+    async fn wait_for_results(
+        &self,
+        response: QueryResponse,
+    ) -> Result<(Option<TableSchema>, Vec<Tuple>)> {
+        let mut schema = response.schema;
+        let mut rows = response.rows.unwrap_or_default();
+        let mut page_token = response.page_token;
+        let job_id = response.job_reference.job_id;
+        let location = response
+            .job_reference
+            .location
+            .or_else(|| Some(self.location.clone()));
+
+        let mut job_complete = response.job_complete;
+        loop {
+            if job_complete && page_token.is_none() {
+                break;
+            }
+
+            let next = self
+                .client
+                .job()
+                .get_query_results(
+                    &self.project_id,
+                    &job_id,
+                    &GetQueryResultsRequest {
+                        page_token,
+                        max_results: Some(PAGE_SIZE),
+                        timeout_ms: Some(200_000),
+                        location: location.clone(),
+                        ..GetQueryResultsRequest::default()
+                    },
+                )
+                .await
+                .map_err(|e| {
+                    GgsqlError::ReaderError(format!("BigQuery result fetch failed: {}", e))
+                })?;
+
+            if let Some(errors) = &next.errors {
+                if !errors.is_empty() {
+                    return Err(GgsqlError::ReaderError(format!(
+                        "BigQuery result fetch failed: {:?}",
+                        errors
+                    )));
+                }
+            }
+
+            if schema.is_none() {
+                schema = next.schema;
+            }
+            rows.extend(next.rows.unwrap_or_default());
+            page_token = next.page_token;
+            job_complete = next.job_complete;
+        }
+
+        Ok((schema, rows))
+    }
+
+    fn query_request(&self, sql: &str) -> QueryRequest {
+        let session_id = self.session_id.borrow().clone();
+        let connection_properties = session_id
+            .map(|value| {
+                vec![ConnectionProperty {
+                    key: "session_id".to_string(),
+                    value,
+                }]
+            })
+            .unwrap_or_default();
+
+        QueryRequest {
+            query: sql.to_string(),
+            max_results: Some(PAGE_SIZE),
+            timeout_ms: Some(200_000),
+            use_legacy_sql: false,
+            location: self.location.clone(),
+            create_session: Some(self.session_id.borrow().is_none()),
+            default_dataset: self.default_dataset.as_ref().map(|dataset_id| {
+                DatasetReference {
+                    project_id: self.project_id.clone(),
+                    dataset_id: dataset_id.clone(),
+                }
+            }),
+            connection_properties,
+            ..QueryRequest::default()
+        }
+    }
+}
+
+impl super::Reader for BigQueryReader {
+    fn execute_sql(&self, sql: &str) -> Result<DataFrame> {
+        let sql = super::data::rewrite_namespaced_sql(sql)?;
+        let sql = sql.replace('"', "`");
+
+        let response = self.runtime.block_on(self.run_query(&sql))?;
+        let (schema, rows) = self.runtime.block_on(self.wait_for_results(response))?;
+
+        let Some(schema) = schema else {
+            return Ok(DataFrame::empty());
+        };
+
+        rows_to_dataframe(&schema, &rows)
+    }
+
+    fn execute(&self, query: &str) -> Result<super::Spec> {
+        super::execute_with_reader(self, query)
+    }
+
+    fn dialect(&self) -> &dyn super::SqlDialect {
+        &BigQueryDialect
+    }
+
+    fn list_catalogs(&self) -> Result<Vec<String>> {
+        let df = self.execute_sql(&BigQueryDialect::sql_list_catalogs())?;
+        let col = df.column("catalog_name")?;
+        Ok((0..df.height())
+            .filter(|&i| !col.is_null(i))
+            .map(|i| crate::array_util::value_to_string(col, i))
+            .collect())
+    }
+
+    fn list_schemas(&self, catalog: &str) -> Result<Vec<String>> {
+        let df = self.execute_sql(&BigQueryDialect::sql_list_schemas(catalog))?;
+        let col = df.column("schema_name")?;
+        Ok((0..df.height())
+            .filter(|&i| !col.is_null(i))
+            .map(|i| crate::array_util::value_to_string(col, i))
+            .collect())
+    }
+
+    fn list_tables(&self, catalog: &str, schema: &str) -> Result<Vec<super::TableInfo>> {
+        let df = self.execute_sql(&BigQueryDialect::sql_list_tables(catalog, schema))?;
+        let name_col = df.column("table_name")?;
+        let type_col = df.column("table_type")?;
+        Ok((0..df.height())
+            .filter(|&i| !name_col.is_null(i))
+            .map(|i| super::TableInfo {
+                name: crate::array_util::value_to_string(name_col, i),
+                table_type: crate::array_util::value_to_string(type_col, i),
+            })
+            .collect())
+    }
+
+    fn list_columns(&self, catalog: &str, schema: &str, table: &str) -> Result<Vec<super::ColumnInfo>> {
+        let df = self.execute_sql(&BigQueryDialect::sql_list_columns(catalog, schema, table))?;
+        let name_col = df.column("column_name")?;
+        let type_col = df.column("data_type")?;
+        Ok((0..df.height())
+            .filter(|&i| !name_col.is_null(i))
+            .map(|i| super::ColumnInfo {
+                name: crate::array_util::value_to_string(name_col, i),
+                data_type: crate::array_util::value_to_string(type_col, i),
+            })
+            .collect())
+    }
+
+    fn register(&self, name: &str, _df: DataFrame, _replace: bool) -> Result<()> {
+        // BigQuery is a remote service; there is no in-process table store to
+        // register Arrow data into. This is not called by the execution pipeline:
+        // CTE materialization uses create_or_replace_temp_table_sql + execute_sql
+        // (BigQuery-native DDL) instead of register().
+        Err(GgsqlError::ReaderError(format!(
+            "BigQueryReader does not support in-process DataFrame registration ('{}')",
+            name
+        )))
+    }
+}
+
+// ============================================================================
+// Row conversion helpers
+// ============================================================================
+
+fn rows_to_dataframe(schema: &TableSchema, rows: &[Tuple]) -> Result<DataFrame> {
+    let arrays = schema
+        .fields
+        .iter()
+        .enumerate()
+        .map(|(idx, field)| {
+            let values = rows
+                .iter()
+                .map(|row| row.f.get(idx).map(|cell| &cell.v).unwrap_or(&Value::Null))
+                .collect::<Vec<_>>();
+            Ok((field.name.clone(), values_to_array(field, &values)?))
+        })
+        .collect::<Result<Vec<_>>>()?;
+
+    DataFrame::new(arrays)
+}
+
+fn values_to_array(field: &TableFieldSchema, values: &[&Value]) -> Result<ArrayRef> {
+    if matches!(
+        field.mode,
+        Some(gcloud_bigquery::http::table::TableFieldMode::Repeated)
+    ) {
+        return Ok(string_array(values));
+    }
+
+    match field.data_type {
+        TableFieldType::Integer | TableFieldType::Int64 => Ok(Arc::new(Int64Array::from(
+            values
+                .iter()
+                .map(|v| value_as_str(v).and_then(|s| s.parse::<i64>().ok()))
+                .collect::<Vec<_>>(),
+        ))),
+        TableFieldType::Float | TableFieldType::Float64 => Ok(Arc::new(Float64Array::from(
+            values
+                .iter()
+                .map(|v| value_as_str(v).and_then(|s| s.parse::<f64>().ok()))
+                .collect::<Vec<_>>(),
+        ))),
+        TableFieldType::Numeric
+        | TableFieldType::Decimal
+        | TableFieldType::Bignumeric
+        | TableFieldType::Bigdecimal => Ok(Arc::new(Float64Array::from(
+            values
+                .iter()
+                .map(|v| value_as_str(v).and_then(|s| s.parse::<f64>().ok()))
+                .collect::<Vec<_>>(),
+        ))),
+        TableFieldType::Boolean | TableFieldType::Bool => Ok(Arc::new(BooleanArray::from(
+            values
+                .iter()
+                .map(|v| value_as_str(v).and_then(|s| s.parse::<bool>().ok()))
+                .collect::<Vec<_>>(),
+        ))),
+        TableFieldType::Date => Ok(Arc::new(Date32Array::from(
+            values
+                .iter()
+                .map(|v| value_as_str(v).and_then(parse_date_days))
+                .collect::<Vec<_>>(),
+        ))),
+        TableFieldType::Timestamp => Ok(Arc::new(TimestampMicrosecondArray::from(
+            values
+                .iter()
+                .map(|v| value_as_str(v).and_then(parse_timestamp_micros))
+                .collect::<Vec<_>>(),
+        ))),
+        TableFieldType::Datetime => Ok(Arc::new(TimestampMicrosecondArray::from(
+            values
+                .iter()
+                .map(|v| value_as_str(v).and_then(parse_datetime_micros))
+                .collect::<Vec<_>>(),
+        ))),
+        TableFieldType::Time => Ok(Arc::new(Time64NanosecondArray::from(
+            values
+                .iter()
+                .map(|v| value_as_str(v).and_then(parse_time_nanos))
+                .collect::<Vec<_>>(),
+        ))),
+        _ => Ok(string_array(values)),
+    }
+}
+
+fn value_as_str(value: &Value) -> Option<&str> {
+    match value {
+        Value::String(s) => Some(s),
+        _ => None,
+    }
+}
+
+fn string_array(values: &[&Value]) -> ArrayRef {
+    let strings = values
+        .iter()
+        .map(|v| match v {
+            Value::String(s) => Some(s.clone()),
+            Value::Null => None,
+            other => Some(format!("{:?}", other)),
+        })
+        .collect::<Vec<_>>();
+    Arc::new(StringArray::from(strings)) as ArrayRef
+}
+
+fn parse_date_days(value: &str) -> Option<i32> {
+    const EPOCH_DAYS_FROM_CE: i32 = 719_163;
+    chrono::NaiveDate::parse_from_str(value, "%Y-%m-%d")
+        .ok()
+        .map(|date| date.num_days_from_ce() - EPOCH_DAYS_FROM_CE)
+}
+
+fn parse_timestamp_micros(value: &str) -> Option<i64> {
+    value
+        .parse::<f64>()
+        .ok()
+        .map(|seconds| (seconds * 1_000_000.0).round() as i64)
+}
+
+fn parse_datetime_micros(value: &str) -> Option<i64> {
+    chrono::NaiveDateTime::parse_from_str(value, "%Y-%m-%dT%H:%M:%S%.f")
+        .or_else(|_| chrono::NaiveDateTime::parse_from_str(value, "%Y-%m-%d %H:%M:%S%.f"))
+        .ok()
+        .map(|dt| dt.and_utc().timestamp_micros())
+}
+
+fn parse_time_nanos(value: &str) -> Option<i64> {
+    chrono::NaiveTime::parse_from_str(value, "%H:%M:%S%.f")
+        .ok()
+        .map(|time| {
+            let seconds = time.num_seconds_from_midnight() as i64;
+            seconds * 1_000_000_000 + time.nanosecond() as i64
+        })
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::reader::{Reader, SqlDialect};
+    use arrow::datatypes::DataType;
+
+    #[test]
+    fn test_bigquery_temp_table_sql_uses_backticks() {
+        let statements = BigQueryDialect.create_or_replace_temp_table_sql(
+            "__ggsql_data",
+            &["x".to_string()],
+            "SELECT 1",
+        );
+        assert_eq!(
+            statements,
+            vec![
+                "CREATE OR REPLACE TEMP TABLE `__ggsql_data` AS WITH __ggsql_aliased__(`x`) AS (SELECT 1) SELECT * FROM __ggsql_aliased__".to_string()
+            ]
+        );
+    }
+
+    #[test]
+    fn test_bigquery_generate_series() {
+        assert_eq!(
+            BigQueryDialect.sql_generate_series(3),
+            "`__ggsql_seq__`(n) AS (SELECT CAST(n AS FLOAT64) AS n FROM UNNEST(GENERATE_ARRAY(0, 2)) AS n)"
+        );
+    }
+
+    #[test]
+    fn test_bigquery_quantile_inline_uses_approx_quantiles() {
+        assert_eq!(
+            BigQueryDialect.sql_quantile_inline("value", 0.25),
+            Some("APPROX_QUANTILES(`value`, 100)[OFFSET(25)]".to_string())
+        );
+        assert_eq!(
+            BigQueryDialect.sql_quantile_inline("value", 0.5),
+            Some("APPROX_QUANTILES(`value`, 100)[OFFSET(50)]".to_string())
+        );
+    }
+
+    #[test]
+    fn test_bigquery_percentile_is_not_correlated() {
+        // sql_percentile must not emit a correlated subquery — BigQuery rejects
+        // those. It delegates to the APPROX_QUANTILES aggregate, valid inside the
+        // GROUP BY queries that boxplot and density build.
+        let sql =
+            BigQueryDialect.sql_percentile("value", 0.75, "SELECT * FROM t", &["g".to_string()]);
+        assert_eq!(sql, "APPROX_QUANTILES(`value`, 100)[OFFSET(75)]");
+        assert!(!sql.contains("SELECT"), "must not be a subquery");
+        assert!(
+            !sql.contains("__ggsql_qt__"),
+            "must not correlate to an outer table"
+        );
+    }
+
+    #[test]
+    fn test_rows_to_dataframe_basic_types() {
+        use gcloud_bigquery::http::tabledata::list::Cell;
+
+        let schema = TableSchema {
+            fields: vec![
+                TableFieldSchema {
+                    name: "i".to_string(),
+                    data_type: TableFieldType::Int64,
+                    ..TableFieldSchema::default()
+                },
+                TableFieldSchema {
+                    name: "s".to_string(),
+                    data_type: TableFieldType::String,
+                    ..TableFieldSchema::default()
+                },
+                TableFieldSchema {
+                    name: "b".to_string(),
+                    data_type: TableFieldType::Bool,
+                    ..TableFieldSchema::default()
+                },
+            ],
+        };
+        let rows = vec![Tuple {
+            f: vec![
+                Cell { v: Value::String("42".to_string()) },
+                Cell { v: Value::String("hello".to_string()) },
+                Cell { v: Value::String("true".to_string()) },
+            ],
+        }];
+
+        let df = rows_to_dataframe(&schema, &rows).unwrap();
+        assert_eq!(df.shape(), (1, 3));
+        assert_eq!(
+            df.get_column_names(),
+            vec!["i".to_string(), "s".to_string(), "b".to_string()]
+        );
+        assert_eq!(df.column_dtype("i").unwrap(), DataType::Int64);
+        assert_eq!(df.column_dtype("s").unwrap(), DataType::Utf8);
+        assert_eq!(df.column_dtype("b").unwrap(), DataType::Boolean);
+    }
+
+    // -------------------------------------------------------------------------
+    // Integration tests — create real infra, run assertions, clean up.
+    //
+    // These tests are #[ignore] by default because they touch live BigQuery.
+    // They share a single dataset/table (created once, cleaned up at process
+    // exit) so individual tests can run in parallel without redundant setup.
+    //
+    // Run all of them with:
+    //
+    //   GGSQL_BIGQUERY_TEST_URI=bigquery://your-project \
+    //     cargo test --features bigquery -- --ignored bq_integration
+    // -------------------------------------------------------------------------
+
+    use std::sync::OnceLock;
+
+    /// RAII fixture: creates a uniquely-named dataset + table, drops both on drop.
+    /// Stored in a static so all integration tests share the same infra.
+    struct BqTestFixture {
+        project_id: String,
+        dataset_id: String,
+        table_id: String,
+    }
+
+    impl BqTestFixture {
+        fn setup(base_uri: &str) -> crate::Result<Self> {
+            // Both ring and aws-lc-rs are in the dep tree; install ring explicitly
+            // so rustls doesn't panic trying to auto-select between them.
+            let _ = rustls::crypto::ring::default_provider().install_default();
+
+            let dataset_id = format!("ggsql_test_{}", uuid::Uuid::new_v4().simple());
+            let table_id = "readings".to_string();
+
+            let bootstrap = BigQueryReader::from_connection_string(base_uri)?;
+            let project_id = bootstrap.project_id().to_string();
+
+            bootstrap.execute_sql(&format!(
+                "CREATE SCHEMA `{}.{}`",
+                project_id, dataset_id
+            ))?;
+            bootstrap.execute_sql(&format!(
+                "CREATE TABLE `{}.{}.{}` AS
+                    SELECT 1 AS id, 'alpha' AS label, 1.5 AS value, TRUE  AS flag UNION ALL
+                    SELECT 2,       'beta',            2.5,          FALSE          UNION ALL
+                    SELECT 3,       'gamma',           3.5,          TRUE",
+                project_id, dataset_id, table_id
+            ))?;
+
+            Ok(Self { project_id, dataset_id, table_id })
+        }
+
+        /// Build a reader whose default dataset points at this fixture's dataset.
+        fn reader(&self) -> crate::Result<BigQueryReader> {
+            BigQueryReader::from_connection_string(&format!(
+                "bigquery://{}/{}",
+                self.project_id, self.dataset_id
+            ))
+        }
+    }
+
+    impl Drop for BqTestFixture {
+        fn drop(&mut self) {
+            if let Ok(reader) = BigQueryReader::from_connection_string(&format!(
+                "bigquery://{}",
+                self.project_id
+            )) {
+                let _ = reader.execute_sql(&format!(
+                    "DROP SCHEMA IF EXISTS `{}.{}` CASCADE",
+                    self.project_id, self.dataset_id
+                ));
+            }
+        }
+    }
+
+    static BQ_FIXTURE: OnceLock<BqTestFixture> = OnceLock::new();
+
+    fn integration_fixture() -> &'static BqTestFixture {
+        BQ_FIXTURE.get_or_init(|| {
+            let uri = std::env::var("GGSQL_BIGQUERY_TEST_URI")
+                .expect("set GGSQL_BIGQUERY_TEST_URI=bigquery://your-project");
+            BqTestFixture::setup(&uri).expect("BQ integration fixture setup failed")
+        })
+    }
+
+    #[test]
+    #[ignore = "touches live BigQuery infra; set GGSQL_BIGQUERY_TEST_URI=bigquery://project and run with --ignored"]
+    fn bq_integration_list_catalogs() {
+        let f = integration_fixture();
+        let reader = f.reader().unwrap();
+        let catalogs = reader.list_catalogs().unwrap();
+        assert!(
+            catalogs.contains(&f.project_id),
+            "expected project '{}' in catalogs, got {:?}",
+            f.project_id, catalogs
+        );
+    }
+
+    #[test]
+    #[ignore = "touches live BigQuery infra; set GGSQL_BIGQUERY_TEST_URI=bigquery://project and run with --ignored"]
+    fn bq_integration_list_schemas() {
+        let f = integration_fixture();
+        let reader = f.reader().unwrap();
+        let schemas = reader.list_schemas(&f.project_id).unwrap();
+        assert!(
+            schemas.contains(&f.dataset_id),
+            "expected dataset '{}' in schemas, got {:?}",
+            f.dataset_id, schemas
+        );
+    }
+
+    #[test]
+    #[ignore = "touches live BigQuery infra; set GGSQL_BIGQUERY_TEST_URI=bigquery://project and run with --ignored"]
+    fn bq_integration_list_tables() {
+        let f = integration_fixture();
+        let reader = f.reader().unwrap();
+        let tables = reader.list_tables(&f.project_id, &f.dataset_id).unwrap();
+        let names: Vec<_> = tables.iter().map(|t| t.name.as_str()).collect();
+        assert!(
+            names.contains(&f.table_id.as_str()),
+            "expected table '{}', got {:?}",
+            f.table_id, names
+        );
+    }
+
+    #[test]
+    #[ignore = "touches live BigQuery infra; set GGSQL_BIGQUERY_TEST_URI=bigquery://project and run with --ignored"]
+    fn bq_integration_list_columns() {
+        let f = integration_fixture();
+        let reader = f.reader().unwrap();
+        let columns = reader
+            .list_columns(&f.project_id, &f.dataset_id, &f.table_id)
+            .unwrap();
+        let names: Vec<_> = columns.iter().map(|c| c.name.as_str()).collect();
+        assert_eq!(names, ["id", "label", "value", "flag"]);
+    }
+
+    #[test]
+    #[ignore = "touches live BigQuery infra; set GGSQL_BIGQUERY_TEST_URI=bigquery://project and run with --ignored"]
+    fn bq_integration_execute_sql() {
+        let f = integration_fixture();
+        let reader = f.reader().unwrap();
+        let df = reader
+            .execute_sql(&format!("SELECT * FROM `{}` ORDER BY id", f.table_id))
+            .unwrap();
+        assert_eq!(df.shape(), (3, 4));
+    }
+
+    #[test]
+    #[ignore = "touches live BigQuery infra; set GGSQL_BIGQUERY_TEST_URI=bigquery://project and run with --ignored"]
+    fn bq_integration_draw_point() {
+        let f = integration_fixture();
+        let reader = f.reader().unwrap();
+        let spec = reader
+            .execute(&format!(
+                "SELECT id, value FROM `{}` ORDER BY id \
+                 VISUALISE id AS x, value AS y DRAW point",
+                f.table_id
+            ))
+            .unwrap();
+        assert_eq!(spec.metadata().rows, 3);
+    }
+
+    #[test]
+    #[ignore = "touches live BigQuery infra; set GGSQL_BIGQUERY_TEST_URI=bigquery://project and run with --ignored"]
+    fn bq_integration_draw_boxplot() {
+        let f = integration_fixture();
+        let reader = f.reader().unwrap();
+        let spec = reader
+            .execute(&format!(
+                "SELECT value FROM `{}` VISUALISE value AS y DRAW boxplot",
+                f.table_id
+            ))
+            .unwrap();
+        assert!(spec.metadata().rows > 0, "boxplot returned no rows");
+    }
+
+    #[test]
+    #[ignore = "touches live BigQuery infra; set GGSQL_BIGQUERY_TEST_URI=bigquery://project and run with --ignored"]
+    fn bq_integration_draw_boxplot_grouped() {
+        // Grouped boxplot drives sql_percentile with a real group column,
+        // exercising the APPROX_QUANTILES aggregate path per quartile.
+        let f = integration_fixture();
+        let reader = f.reader().unwrap();
+        let spec = reader
+            .execute(&format!(
+                "SELECT flag, value FROM `{}` \
+                 VISUALISE value AS y, flag AS fill DRAW boxplot",
+                f.table_id
+            ))
+            .unwrap();
+        assert!(spec.metadata().rows > 0, "grouped boxplot returned no rows");
+    }
+
+    #[test]
+    #[ignore = "touches live BigQuery infra; set GGSQL_BIGQUERY_TEST_URI=bigquery://project and run with --ignored"]
+    fn bq_integration_draw_histogram() {
+        let f = integration_fixture();
+        let reader = f.reader().unwrap();
+        let spec = reader
+            .execute(&format!(
+                "SELECT value FROM `{}` VISUALISE value AS x DRAW histogram",
+                f.table_id
+            ))
+            .unwrap();
+        assert!(spec.metadata().rows > 0, "histogram returned no rows");
+    }
+}

--- a/src/reader/connection.rs
+++ b/src/reader/connection.rs
@@ -20,6 +20,18 @@ pub enum ConnectionInfo {
     /// Generic ODBC connection (raw connection string after `odbc://` prefix)
     #[allow(dead_code)]
     ODBC(String),
+    /// Google BigQuery native connection.
+    #[allow(dead_code)]
+    BigQuery(BigQueryConnectionInfo),
+}
+
+/// Parsed BigQuery connection information.
+#[derive(Debug, Clone, PartialEq)]
+pub struct BigQueryConnectionInfo {
+    /// Explicit project ID, or `None` to resolve from ADC / environment.
+    pub project_id: Option<String>,
+    pub default_dataset: Option<String>,
+    pub location: Option<String>,
 }
 
 /// Parse a connection string into connection information
@@ -30,7 +42,7 @@ pub enum ConnectionInfo {
 /// - `duckdb://...` - DuckDB path
 /// - `postgres://...` - PostgreSQL connection string
 /// - `sqlite://...` - SQLite file path
-/// ```
+/// - `bigquery://[project[/dataset]][?location=US]` - Google BigQuery (project defaults to ADC)
 pub fn parse_connection_string(uri: &str) -> Result<ConnectionInfo> {
     if uri == "duckdb://memory" {
         return Ok(ConnectionInfo::DuckDBMemory);
@@ -67,8 +79,32 @@ pub fn parse_connection_string(uri: &str) -> Result<ConnectionInfo> {
         return Ok(ConnectionInfo::ODBC(conn_str.to_string()));
     }
 
+    if let Some(rest) = uri.strip_prefix("bigquery://") {
+        let (path, query) = rest.split_once('?').unwrap_or((rest, ""));
+        let mut parts = path.split('/').filter(|s| !s.is_empty());
+        let project_id = parts.next().map(|s| s.to_string());
+        let default_dataset = parts.next().map(|s| s.to_string());
+
+        if parts.next().is_some() {
+            return Err(GgsqlError::ReaderError(
+                "BigQuery URI must be bigquery://[project[/dataset]][?location=...]".to_string(),
+            ));
+        }
+
+        let location = query.split('&').find_map(|part| {
+            let (key, value) = part.split_once('=')?;
+            (key == "location" && !value.is_empty()).then(|| value.to_string())
+        });
+
+        return Ok(ConnectionInfo::BigQuery(BigQueryConnectionInfo {
+            project_id,
+            default_dataset,
+            location,
+        }));
+    }
+
     Err(GgsqlError::ReaderError(format!(
-        "Unsupported connection string format: {}. Supported: duckdb://, postgres://, sqlite://, odbc://",
+        "Unsupported connection string format: {}. Supported: duckdb://, postgres://, sqlite://, odbc://, bigquery://",
         uri
     )))
 }
@@ -179,5 +215,45 @@ mod tests {
             .unwrap_err()
             .to_string()
             .contains("Unsupported connection string"));
+    }
+
+    #[test]
+    fn test_bigquery_bare() {
+        let info = parse_connection_string("bigquery://").unwrap();
+        assert_eq!(
+            info,
+            ConnectionInfo::BigQuery(BigQueryConnectionInfo {
+                project_id: None,
+                default_dataset: None,
+                location: None,
+            })
+        );
+    }
+
+    #[test]
+    fn test_bigquery_project() {
+        let info = parse_connection_string("bigquery://my-project").unwrap();
+        assert_eq!(
+            info,
+            ConnectionInfo::BigQuery(BigQueryConnectionInfo {
+                project_id: Some("my-project".to_string()),
+                default_dataset: None,
+                location: None,
+            })
+        );
+    }
+
+    #[test]
+    fn test_bigquery_project_dataset_location() {
+        let info = parse_connection_string("bigquery://my-project/analytics?location=asia-northeast1")
+            .unwrap();
+        assert_eq!(
+            info,
+            ConnectionInfo::BigQuery(BigQueryConnectionInfo {
+                project_id: Some("my-project".to_string()),
+                default_dataset: Some("analytics".to_string()),
+                location: Some("asia-northeast1".to_string()),
+            })
+        );
     }
 }

--- a/src/reader/mod.rs
+++ b/src/reader/mod.rs
@@ -342,6 +342,9 @@ pub mod odbc;
 #[cfg(feature = "adbc")]
 pub mod adbc;
 
+#[cfg(feature = "bigquery")]
+pub mod bigquery;
+
 pub mod connection;
 pub mod data;
 mod spec;
@@ -357,6 +360,9 @@ pub use odbc::OdbcReader;
 
 #[cfg(feature = "adbc")]
 pub use adbc::AdbcReader;
+
+#[cfg(feature = "bigquery")]
+pub use bigquery::BigQueryReader;
 
 // ============================================================================
 // Shared utilities


### PR DESCRIPTION
Hello! 
Since this is my PR here, I wanted to give a short introduction.
My name is Gajo, and at my work we use BigQuery a lot. This looks like an interesting project, and I would like to give it a go, so I decided to try adding BigQuery support. 

All the code in this PR was written by Claude but I did my review and got it to a reasonable state.
I purposefully didn't add it to the default feature set, as I'm not sure which direction you would like to take, but I think it would be nice if we could add it later. Maybe even in this PR?

As I was writing this, I hit two problems with the current implementation of Histogram & Percentile, and tbh I'm not familiar with the library enough to tell if this is the right way of handling it. Learning about the finer details felt a bit daunting/somewhat out of scope for what I wanted to do in this PR. I did manage to satisfy the tests at least... but anyway, this is something that I'd take a deeper look at.

On testing, I added a couple of your usual unit tests, but I also added some integration tests, that create real tables and demonstrate that this works with real BigQuery, but since this requires a real infrastructure I've made them disabled by default. I did manage to confirm that they pass in one of my projects.

As a future PR, I would like to add some examples for DuckDB and BigQuery, something users can easily run. I would also like to dig a bit deeper in the security design of this, in case ggsql is used behind a library where user input might not be trusted (I'm not yet sure how you would support [parametrized queries](https://docs.cloud.google.com/bigquery/docs/parameterized-queries) here). Also personally not a fan of large files, and if it's OK with you, I'd at least split the bigquery reader into a few files.. but leaving this up to you.

Regarding this PR, if you would like to first discuss the approach or maybe start with something smaller, please let me know. I can understand the potential maintenance burden of adding new features from new contributors - the drive-by PR is certainly a thing these days.

Below is AI generated PR message

-----

feature flag (enable with `--features bigquery`, or `all-readers`).

- **`BigQueryReader`** (`src/reader/bigquery.rs`) — authenticates via Application
  Default Credentials using the `gcloud-bigquery` crate; paginates results and
  converts them to Arrow.
- **Connection string** `bigquery://[PROJECT[/DATASET]][?location=REGION]` — the
  project is optional and resolves from ADC / `GOOGLE_CLOUD_PROJECT` when
  omitted; an optional dataset sets the default dataset; `location` defaults to
  `US`.
- **`BigQueryDialect`** — backtick quoting, BigQuery type names
  (`INT64`/`FLOAT64`/`STRING`/`DATETIME`), `GREATEST`/`LEAST`, `GENERATE_ARRAY`
  series, `APPROX_QUANTILES` quantiles, and `CREATE OR REPLACE TEMP TABLE`.
- VS Code / Positron connection picker and the Jupyter kernel both accept
  `bigquery://`; `cli.qmd` documents the scheme and ADC auth.

## SQL portability fixes

Two SQL-generation issues surfaced under BigQuery's stricter semantics. Both
fixes are output-identical on DuckDB/SQLite:

- **Histogram** — `bin_end` and `density` are now derived in the outer SELECT
  from the already-grouped `bin`/`count` columns, instead of inside the GROUP BY
  query. BigQuery rejects a GROUP BY query whose SELECT list references an input
  column outside the grouping key.
- **Percentile** — `sql_percentile` / `sql_quantile_inline` emit the
  `APPROX_QUANTILES` aggregate instead of a correlated scalar subquery, which
  BigQuery rejects for grouped boxplot / density.

## Testing

- Live integration tests (`bq_integration_*`) — `#[ignore]` by default, opt in
  via `GGSQL_BIGQUERY_TEST_URI`. They create a uuid-named dataset (auto-dropped)
  and cover catalog/schema/table/column introspection, `execute_sql`,
  point/boxplot/grouped-boxplot/histogram rendering, type conversion, result
  pagination, and query-error propagation.
- Dialect unit tests for quoting, series generation, and quantile SQL.
- Full workspace test suite green; `clippy` clean with `--features bigquery`.

## Follow-ups (not in this PR)

- CI does not yet compile-check the `bigquery` feature; it should gain steps
  mirroring the existing ADBC ones, or `bigquery.rs` will bitrot.
- Release binaries (`ggsql`, `ggsql-jupyter`) build with default features and so
  do not include `bigquery` — needs a decision on whether to ship it.
- `src/CLAUDE.md` / `ggsql-jupyter/CLAUDE.md` reader and feature-flag tables need
  updating to list `bigquery` (and `adbc`).