### PR TITLE
Labels for numeric scales compare on `datum.value`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@
 - Dodging of horizontal violin plots were broken due to a bad orientation
   assumption in the VegaLite writer. We now correctly use the orientation to
   dodge in the correct dimension (#439).
+- Fixed misbehaviour of numeric scale's `RENAMING` clause due to pre-formatting 
+  issues (#461)
 
 ### Changed
 

--- a/src/format.rs
+++ b/src/format.rs
@@ -72,10 +72,21 @@ fn parse_placeholders(template: &str) -> Vec<ParsedPlaceholder> {
         .collect()
 }
 
-/// Apply transformation based on placeholder type
-fn apply_transformation(value: &str, placeholder: &Placeholder) -> String {
+/// Apply transformation based on placeholder type.
+/// `precision` controls decimal places for `Plain` placeholders on numeric values.
+fn apply_transformation(
+    value: &str,
+    placeholder: &Placeholder,
+    precision: Option<usize>,
+) -> String {
     match placeholder {
-        Placeholder::Plain => value.to_string(),
+        Placeholder::Plain => match precision {
+            Some(prec) => match value.parse::<f64>() {
+                Ok(n) => format!("{n:.prec$}"),
+                Err(_) => value.to_string(),
+            },
+            None => value.to_string(),
+        },
         Placeholder::Upper => value.to_uppercase(),
         Placeholder::Lower => value.to_lowercase(),
         Placeholder::Title => to_title_case(value),
@@ -172,6 +183,19 @@ pub fn apply_label_template(
     // Parse all placeholders once
     let placeholders = parse_placeholders(template);
 
+    // For numeric breaks with a plain placeholder, determine consistent decimal
+    // precision so that e.g. [54.5, 55, 55.5] formats as ["54.5", "55.0", "55.5"]
+    // rather than stripping the ".0" from the integer-valued break.
+    let has_plain = placeholders
+        .iter()
+        .any(|p| matches!(p.placeholder, Placeholder::Plain))
+        || placeholders.is_empty();
+    let numeric_precision = if has_plain {
+        compute_numeric_precision(breaks)
+    } else {
+        None
+    };
+
     for elem in breaks {
         // Skip null values
         if matches!(elem, ArrayElement::Null) {
@@ -181,12 +205,51 @@ pub fn apply_label_template(
 
         // Only apply template if no explicit mapping exists
         result.entry(key.clone()).or_insert_with(|| {
-            // Use shared format_value helper
-            Some(format_value(&key, template, &placeholders))
+            Some(format_value(
+                &key,
+                template,
+                &placeholders,
+                numeric_precision,
+            ))
         });
     }
 
     result
+}
+
+/// Determine the minimum decimal precision needed to represent all numeric breaks
+/// consistently. Returns `None` if there are no numeric breaks or all are integers.
+fn compute_numeric_precision(breaks: &[ArrayElement]) -> Option<usize> {
+    let mut max_decimals: usize = 0;
+    let mut has_numbers = false;
+
+    for elem in breaks {
+        if let ArrayElement::Number(n) = elem {
+            has_numbers = true;
+            let decimals = decimal_places(*n);
+            if decimals > max_decimals {
+                max_decimals = decimals;
+            }
+        }
+    }
+
+    if has_numbers && max_decimals > 0 {
+        Some(max_decimals)
+    } else {
+        None
+    }
+}
+
+/// Count the number of meaningful decimal places in a float.
+fn decimal_places(n: f64) -> usize {
+    if n.fract().abs() < f64::EPSILON * n.abs().max(1.0) {
+        return 0;
+    }
+    let s = format!("{}", n);
+    match s.find('.') {
+        Some(pos) => s.len() - pos - 1,
+        None => 0,
+    }
 }
 
 /// Apply label formatting template to a DataFrame column.
@@ -258,7 +321,7 @@ pub fn format_dataframe_column(
     let placeholders = parse_placeholders(template);
     let formatted_owned: Vec<Option<String>> = string_values
         .into_iter()
-        .map(|opt| opt.map(|s| format_value(&s, template, &placeholders)))
+        .map(|opt| opt.map(|s| format_value(&s, template, &placeholders, None)))
         .collect();
 
     let formatted_refs: Vec<Option<&str>> =
@@ -271,7 +334,12 @@ pub fn format_dataframe_column(
 }
 
 /// Format a single value using template and parsed placeholders
-fn format_value(value: &str, template: &str, placeholders: &[ParsedPlaceholder]) -> String {
+fn format_value(
+    value: &str,
+    template: &str,
+    placeholders: &[ParsedPlaceholder],
+    precision: Option<usize>,
+) -> String {
     if placeholders.is_empty() {
         // No placeholders - use template as literal string
         template.to_string()
@@ -279,7 +347,7 @@ fn format_value(value: &str, template: &str, placeholders: &[ParsedPlaceholder])
         // Replace each placeholder with its transformed value
         let mut result = template.to_string();
         for parsed in placeholders.iter().rev() {
-            let transformed = apply_transformation(value, &parsed.placeholder);
+            let transformed = apply_transformation(value, &parsed.placeholder, precision);
             result = result.replace(&parsed.match_text, &transformed);
         }
         result
@@ -504,5 +572,33 @@ mod tests {
         let result = apply_label_template(&breaks, "{:num %d}", &None);
 
         assert_eq!(result.get("42"), Some(&Some("42".to_string())));
+    }
+
+    #[test]
+    fn test_plain_placeholder_consistent_decimal_precision() {
+        let breaks = vec![
+            ArrayElement::Number(54.5),
+            ArrayElement::Number(55.0),
+            ArrayElement::Number(55.5),
+        ];
+        let result = apply_label_template(&breaks, "{}", &None);
+
+        assert_eq!(result.get("54.5"), Some(&Some("54.5".to_string())));
+        assert_eq!(result.get("55"), Some(&Some("55.0".to_string())));
+        assert_eq!(result.get("55.5"), Some(&Some("55.5".to_string())));
+    }
+
+    #[test]
+    fn test_plain_placeholder_all_integers_no_decimals() {
+        let breaks = vec![
+            ArrayElement::Number(10.0),
+            ArrayElement::Number(20.0),
+            ArrayElement::Number(30.0),
+        ];
+        let result = apply_label_template(&breaks, "{}", &None);
+
+        assert_eq!(result.get("10"), Some(&Some("10".to_string())));
+        assert_eq!(result.get("20"), Some(&Some("20".to_string())));
+        assert_eq!(result.get("30"), Some(&Some("30".to_string())));
     }
 }

--- a/src/format.rs
+++ b/src/format.rs
@@ -217,38 +217,52 @@ pub fn apply_label_template(
     result
 }
 
-/// Determine the minimum decimal precision needed to represent all numeric breaks
-/// consistently. Returns `None` if there are no numeric breaks or all are integers.
+/// Determine the number of decimal places needed to display numeric breaks
+/// consistently. Based on the algorithm from R's `scales::precision()`:
+/// uses the smallest inter-break difference to derive display precision.
+/// Returns `None` if there are fewer than 2 numeric breaks or all are integers.
 fn compute_numeric_precision(breaks: &[ArrayElement]) -> Option<usize> {
-    let mut max_decimals: usize = 0;
-    let mut has_numbers = false;
+    let tol = f64::EPSILON.sqrt();
 
-    for elem in breaks {
-        if let ArrayElement::Number(n) = elem {
-            has_numbers = true;
-            let decimals = decimal_places(*n);
-            if decimals > max_decimals {
-                max_decimals = decimals;
-            }
-        }
+    let mut numbers: Vec<f64> = breaks
+        .iter()
+        .filter_map(|e| match e {
+            ArrayElement::Number(n) => Some(*n),
+            _ => None,
+        })
+        .collect();
+
+    if numbers.len() < 2 {
+        return None;
     }
 
-    if has_numbers && max_decimals > 0 {
-        Some(max_decimals)
+    numbers.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+
+    let smallest_diff = numbers
+        .windows(2)
+        .map(|w| (w[1] - w[0]).abs())
+        .filter(|d| *d > 0.0)
+        .fold(f64::INFINITY, f64::min);
+
+    if smallest_diff == f64::INFINITY || smallest_diff < tol {
+        return None;
+    }
+
+    let mut precision = 10f64.powf(smallest_diff.log10().floor() - 1.0);
+
+    // If all values are multiples of 10*precision, coarsen by one level
+    if numbers
+        .iter()
+        .all(|&x| ((x / precision).round() % 10.0).abs() < tol)
+    {
+        precision *= 10.0;
+    }
+
+    let n_decimals = (-precision.log10().floor()) as isize;
+    if n_decimals > 0 {
+        Some(n_decimals.min(20) as usize)
     } else {
         None
-    }
-}
-
-/// Count the number of meaningful decimal places in a float.
-fn decimal_places(n: f64) -> usize {
-    if n.fract().abs() < f64::EPSILON * n.abs().max(1.0) {
-        return 0;
-    }
-    let s = format!("{}", n);
-    match s.find('.') {
-        Some(pos) => s.len() - pos - 1,
-        None => 0,
     }
 }
 
@@ -600,5 +614,19 @@ mod tests {
         assert_eq!(result.get("10"), Some(&Some("10".to_string())));
         assert_eq!(result.get("20"), Some(&Some("20".to_string())));
         assert_eq!(result.get("30"), Some(&Some("30".to_string())));
+    }
+
+    #[test]
+    fn test_plain_placeholder_small_fractional_steps() {
+        let breaks = vec![
+            ArrayElement::Number(0.0),
+            ArrayElement::Number(0.05),
+            ArrayElement::Number(0.1),
+        ];
+        let result = apply_label_template(&breaks, "{}", &None);
+
+        assert_eq!(result.get("0"), Some(&Some("0.00".to_string())));
+        assert_eq!(result.get("0.05"), Some(&Some("0.05".to_string())));
+        assert_eq!(result.get("0.1"), Some(&Some("0.10".to_string())));
     }
 }

--- a/src/writer/vegalite/encoding.rs
+++ b/src/writer/vegalite/encoding.rs
@@ -765,8 +765,12 @@ fn apply_label_mapping_to_encoding(
         (label_mapping.clone(), None)
     };
 
-    let label_expr =
-        build_label_expr(&filtered_mapping, time_format, null_key.as_deref(), field_type);
+    let label_expr = build_label_expr(
+        &filtered_mapping,
+        time_format,
+        null_key.as_deref(),
+        field_type,
+    );
 
     if is_position_aesthetic(aesthetic) {
         insert_axis_property(encoding, "labelExpr", json!(label_expr));

--- a/src/writer/vegalite/encoding.rs
+++ b/src/writer/vegalite/encoding.rs
@@ -26,9 +26,14 @@ fn is_free(aesthetic: &str, facet: Option<&crate::plot::Facet>) -> bool {
 /// - `Some(label)` -> rename to that label
 /// - `None` -> suppress label (empty string)
 ///
-/// For non-temporal scales:
+/// For nominal/ordinal scales:
 /// - Uses `datum.label` for comparisons
 /// - Example: `"datum.label == 'A' ? 'Alpha' : datum.label == 'B' ? 'Beta' : datum.label"`
+///
+/// For quantitative scales:
+/// - Uses `datum.value` for comparisons (numeric, no quotes) to avoid locale formatting
+///   mismatches (e.g., `datum.label` may contain thousand separators like "2,020")
+/// - Example: `"datum.value == 2020 ? '2020.0' : datum.label"`
 ///
 /// For temporal scales:
 /// - Uses `utcFormat(datum.value, 'fmt')` for comparisons (UTC to match our ISO date strings)
@@ -44,17 +49,21 @@ pub(super) fn build_label_expr(
     mappings: &HashMap<String, Option<String>>,
     time_format: Option<&str>,
     null_key: Option<&str>,
+    field_type: &str,
 ) -> String {
     if mappings.is_empty() {
         return "datum.label".to_string();
     }
 
-    // Build the comparison expression based on whether this is temporal
-    // Use utcFormat (not timeFormat) because ggsql writes ISO date strings as UTC.
-    // timeFormat uses the browser's local timezone, causing comparison mismatches
-    // (e.g., "2024-01-01" UTC midnight becomes "2023-12-31" in US timezones).
+    let is_numeric = field_type == "quantitative";
+
+    // Build the comparison expression based on scale type.
+    // - Temporal: use utcFormat(datum.value, fmt) because timeFormat uses local tz.
+    // - Numeric: use datum.value to avoid locale thousand-separator mismatches.
+    // - Otherwise: use datum.label (categorical/string).
     let comparison_expr = match time_format {
         Some(fmt) => format!("utcFormat(datum.value, '{}')", fmt),
+        None if is_numeric => "datum.value".to_string(),
         None => "datum.label".to_string(),
     };
 
@@ -66,6 +75,8 @@ pub(super) fn build_label_expr(
             // For threshold scales, the first terminal uses null instead of string comparison
             let condition = if null_key == Some(from.as_str()) {
                 "datum.label == null".to_string()
+            } else if is_numeric && time_format.is_none() {
+                format!("{} == {}", comparison_expr, from_escaped)
             } else {
                 format!("{} == '{}'", comparison_expr, from_escaped)
             };
@@ -691,6 +702,7 @@ fn apply_label_mapping_to_encoding(
     aesthetic: &str,
     is_binned_legend: bool,
     spec: &Plot,
+    field_type: &str,
 ) {
     use crate::plot::scale::TransformKind;
     use crate::plot::ParameterValue;
@@ -753,7 +765,8 @@ fn apply_label_mapping_to_encoding(
         (label_mapping.clone(), None)
     };
 
-    let label_expr = build_label_expr(&filtered_mapping, time_format, null_key.as_deref());
+    let label_expr =
+        build_label_expr(&filtered_mapping, time_format, null_key.as_deref(), field_type);
 
     if is_position_aesthetic(aesthetic) {
         insert_axis_property(encoding, "labelExpr", json!(label_expr));
@@ -882,6 +895,7 @@ fn build_column_encoding(
             aesthetic,
             is_binned_legend,
             ctx.spec,
+            &field_type,
         );
 
         (scale_obj, needs_gradient)
@@ -1123,7 +1137,7 @@ mod tests {
         let mut mappings = HashMap::new();
         mappings.insert("2024-01-01".to_string(), Some("Jan 2024".to_string()));
 
-        let expr = build_label_expr(&mappings, Some("%Y-%m-%d"), None);
+        let expr = build_label_expr(&mappings, Some("%Y-%m-%d"), None, "temporal");
 
         assert!(
             expr.contains("utcFormat("),
@@ -1144,7 +1158,7 @@ mod tests {
         let mut mappings = HashMap::new();
         mappings.insert("A".to_string(), Some("Alpha".to_string()));
 
-        let expr = build_label_expr(&mappings, None, None);
+        let expr = build_label_expr(&mappings, None, None, "nominal");
 
         assert!(
             expr.contains("datum.label == 'A'"),
@@ -1159,7 +1173,7 @@ mod tests {
     #[test]
     fn test_build_label_expr_fallback() {
         let mappings = HashMap::new();
-        let expr = build_label_expr(&mappings, Some("%Y-%m-%d"), None);
+        let expr = build_label_expr(&mappings, Some("%Y-%m-%d"), None, "temporal");
         assert_eq!(
             expr, "datum.label",
             "empty mappings should fall back to datum.label"
@@ -1171,11 +1185,28 @@ mod tests {
         let mut mappings = HashMap::new();
         mappings.insert("2024-06-01".to_string(), None); // suppress label
 
-        let expr = build_label_expr(&mappings, Some("%Y-%m-%d"), None);
+        let expr = build_label_expr(&mappings, Some("%Y-%m-%d"), None, "temporal");
 
         assert!(
             expr.contains("? ''"),
             "None mapping should suppress label (empty string), got: {expr}"
+        );
+    }
+
+    #[test]
+    fn test_build_label_expr_quantitative_uses_datum_value() {
+        let mut mappings = HashMap::new();
+        mappings.insert("2020".to_string(), Some("2020.0".to_string()));
+
+        let expr = build_label_expr(&mappings, None, None, "quantitative");
+
+        assert!(
+            expr.contains("datum.value == 2020 ? '2020.0'"),
+            "quantitative should use datum.value with unquoted comparison, got: {expr}"
+        );
+        assert!(
+            !expr.contains("datum.label =="),
+            "quantitative should not use datum.label for comparison, got: {expr}"
         );
     }
 


### PR DESCRIPTION
This PR aims to fix #461.

The issue is that `datum.label == '2000' ? '2000'` didn't work because the label was actually '2,000' instead of '2000'. 
In this PR, we compare `datum.value` to unquoted numbers instead.
Most of it is plumbing to get the right information to the right place.