### PR TITLE
Improvements to hinges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@
 - Added `radar` setting to polar coordinates for making radar plots (#418).
 - New `side` SETTING on the `boxplot` layer and the `jitter` position, mirroring
   the existing `violin` setting (#439).
+- New `hinge` SETTING on the `boxplot` layer, mirroring the existing `range` 
+  setting (#438)
 
 ### Fixed
 
@@ -31,6 +33,8 @@
   aesthetic, matching `bar`. `point` now treats both position aesthetics as
   optional.
 - Upgraded dependencies: duckdb-rs v1.10502, arrow v58 (#447).
+- Renamed the `width` setting in the `range` layer to `hinge`. This prevents
+  it from clashing with `width` needed by `position => 'dodge'` (#437).
 
 ## 0.3.3 - 2026-05-27
 

--- a/doc/syntax/layer/type/boxplot.qmd
+++ b/doc/syntax/layer/type/boxplot.qmd
@@ -29,6 +29,7 @@ The following aesthetics are recognised by the boxplot layer.
 * `outliers`: Whether to display outliers as points. Defaults to `true`.
 * `coef`: Length of the whiskers as a multiple of the IQR (must be >= 0). Defaults to `1.5`.
 * `width`: Relative width of the boxes (0 to 1). Defaults to `0.9`.
+* `hinge`: The width of the whisker caps in points (must be >= 0). Defaults to `null` (no caps). Set to a number to display tick marks at the whisker endpoints.
 * `side`: Determines the sides of the centerline where the box is displayed. Only the box and median tick shift to the chosen side; whiskers and outliers remain on the centerline. The full `width` is preserved for dodge calculations, so a half-box pairs cleanly with a half-violin or one-sided jitter on the same band. One of:
     * `'both'` (default) displays a complete box on both sides of the centerline.
     * `'left'` or `'bottom'` displays only the half-box on the left side or bottom side.

--- a/doc/syntax/layer/type/boxplot.qmd
+++ b/doc/syntax/layer/type/boxplot.qmd
@@ -30,7 +30,7 @@ The following aesthetics are recognised by the boxplot layer.
 * `coef`: Length of the whiskers as a multiple of the IQR (must be >= 0). Defaults to `1.5`.
 * `width`: Relative width of the boxes (0 to 1). Defaults to `0.9`.
 * `hinge`: The width of the whisker caps in points (must be >= 0). Defaults to `null` (no caps). Set to a number to display tick marks at the whisker endpoints.
-* `side`: Determines the sides of the centerline where the box is displayed. Only the box and median tick shift to the chosen side; whiskers and outliers remain on the centerline. The full `width` is preserved for dodge calculations, so a half-box pairs cleanly with a half-violin or one-sided jitter on the same band. One of:
+* `side`: Determines the sides of the centerline where the box is displayed. The box, median and hinges shift to the chosen side; whiskers and outliers remain on the centerline. The full `width` is preserved for dodge calculations, so a half-box pairs cleanly with a half-violin or one-sided jitter on the same band. One of:
     * `'both'` (default) displays a complete box on both sides of the centerline.
     * `'left'` or `'bottom'` displays only the half-box on the left side or bottom side.
     * `'right'` or `'top'` displays only the half-box on the right side or top side.

--- a/doc/syntax/layer/type/range.qmd
+++ b/doc/syntax/layer/type/range.qmd
@@ -23,7 +23,7 @@ The following aesthetics are recognised by the range layer.
 * `linetype`: The dash pattern of the lines in the range.
 
 ## Settings
-* `width`: The width of the hinges in points (must be >= 0). Defaults to 10. Can be set to `null` to not display hinges.
+* `hinge`: The width of the hinges in points (must be >= 0). Defaults to 10. Can be set to `null` to not display hinges.
 * `aggregate` Aggregation functions to apply per group: 
     * `null` apply no group aggregation (default).
     * A single string or an array of strings. See an overview of aggregation function in [the `DRAW` documentation](../../clause/draw.qmd#aggregate) and more information in the *Data transformation* section below.
@@ -65,18 +65,18 @@ Dynamite plot using bars instead of points, with extra wide hinges.
 VISUALISE species AS x FROM penguin_summary
 DRAW range
   MAPPING low AS ymax, high AS ymin
-  SETTING width => 40
+  SETTING hinge => 40
 DRAW bar
   MAPPING mean AS y
 ```
 
-The hinges can be omitted by setting `null` as width, leaving just the line segment between the endpoints.
+The hinges can be omitted by setting `null` as hinge, leaving just the line segment between the endpoints.
 
 ```{ggsql}
 VISUALISE species AS x FROM penguin_summary
 DRAW range
   MAPPING low AS ymax, high AS ymin
-  SETTING width => null
+  SETTING hinge => null
 ```
 
 A horizontal range can be rendered by swapping the `x` and `y` directions.
@@ -108,10 +108,10 @@ GROUP BY Week
 VISUALISE date AS x, trend AS colour
 DRAW range
   MAPPING open AS ymin, close AS ymax
-  SETTING linewidth => 5, width => null
+  SETTING linewidth => 5, hinge => null
 DRAW range
   MAPPING low AS ymin, high AS ymax
-  SETTING width => null
+  SETTING hinge => null
 ```
 
 Rather than precomputing the values and plotting them, you can use the aggregate functionality to calculate the relevant statistics dynamically:
@@ -128,7 +128,7 @@ DRAW range
       'ymax:last', 'ymax:max', 
       'color:diff'
     ), 
-    width => null
+    hinge => null
   PARTITION BY Week
 SCALE linewidth TO (5, 1)
 SCALE BINNED color TO ('steelblue', 'firebrick')

--- a/doc/vendor/SKILL.md
+++ b/doc/vendor/SKILL.md
@@ -404,7 +404,7 @@ DRAW histogram MAPPING body_mass AS x REMAPPING density AS y  -- density instead
 Kernel density estimation. Required: x. Stats: `density`, `intensity`. Settings: `position` (default `'identity'`), `bandwidth`, `adjust` (default 1), `kernel` (`'gaussian'` default, `'epanechnikov'`, `'triangular'`, `'rectangular'`, `'biweight'`, `'cosine'`).
 
 ### boxplot
-Five-number summary with outliers. Required: x (categorical), y (continuous). Stats: `type`, `value`. Settings: `position` (default `'dodge'`), `outliers` (default true), `coef` (whisker IQR multiple, default 1.5), `width` (default 0.9).
+Five-number summary with outliers. Required: x (categorical), y (continuous). Stats: `type`, `value`. Settings: `position` (default `'dodge'`), `outliers` (default true), `coef` (whisker IQR multiple, default 1.5), `width` (default 0.9), `hinge` (whisker cap width in points, default null/hidden).
 
 ### violin
 Mirrored kernel density for groups. Required: x (categorical), y (continuous). Stats: `density`, `intensity`. Default remapping: `density AS offset`. Settings: `position` (default `'dodge'`), `bandwidth`, `adjust`, `kernel` (same as density), `width` (default 0.9), `side` (`'both'`/`'left'`/`'bottom'`/`'right'`/`'top'`), `tails` (number or null, default 3).

--- a/doc/vendor/SKILL.md
+++ b/doc/vendor/SKILL.md
@@ -434,7 +434,7 @@ Rectangles. Required: pick 2 per axis from center (x/y), min (xmin/ymin), max (x
 Closed shapes from ordered coordinates. Required: x, y. Use PARTITION BY to separate distinct polygons.
 
 ### range
-Range/interval display between two values along the secondary axis. Required: x, ymin, ymax. Settings: `width` (hinge width in points, default 10, null to hide).
+Range/interval display between two values along the secondary axis. Required: x, ymin, ymax. Settings: `hinge` (hinge width in points, default 10, null to hide).
 
 All layers accept common optional aesthetics (colour/stroke, fill, opacity, linewidth, linetype) and `position` setting where applicable.
 
@@ -469,7 +469,7 @@ SCALE x VIA date
 -- Lollipop chart
 SELECT ROUND(bill_dep) AS bill_dep, COUNT(*) AS n FROM ggsql:penguins GROUP BY 1
 VISUALISE bill_dep AS x
-DRAW range MAPPING 0 AS ymin, n AS ymax SETTING width => null
+DRAW range MAPPING 0 AS ymin, n AS ymax SETTING hinge => null
 DRAW point MAPPING n AS y
 
 -- Ridgeline / joy plot
@@ -496,7 +496,7 @@ VISUALISE Date AS x, Temp AS ymin, Temp AS ymax, Temp AS color
   FROM ggsql:airquality
 DRAW range
   SETTING aggregate => ('x:first', 'ymin:first', 'ymax:last', 'color:diff'),
-          width => null
+          hinge => null
   PARTITION BY Week
 SCALE BINNED color
 

--- a/src/plot/layer/geom/boxplot.rs
+++ b/src/plot/layer/geom/boxplot.rs
@@ -67,6 +67,11 @@ impl GeomTrait for Boxplot {
                 constraint: ParamConstraint::number_range(0.0, 1.0),
             },
             ParamDefinition {
+                name: "hinge",
+                default: DefaultParamValue::Null,
+                constraint: ParamConstraint::number_min(0.0),
+            },
+            ParamDefinition {
                 name: "position",
                 default: DefaultParamValue::String("dodge"),
                 constraint: ParamConstraint::string_option(POSITION_VALUES),
@@ -560,7 +565,7 @@ mod tests {
         let boxplot = Boxplot;
         let params = boxplot.default_params();
 
-        assert_eq!(params.len(), 5);
+        assert_eq!(params.len(), 6);
 
         // Find and verify outliers param
         let outliers_param = params.iter().find(|p| p.name == "outliers").unwrap();

--- a/src/plot/layer/geom/range.rs
+++ b/src/plot/layer/geom/range.rs
@@ -40,7 +40,7 @@ impl GeomTrait for Range {
                 constraint: ParamConstraint::string_option(POSITION_VALUES),
             },
             ParamDefinition {
-                name: "width",
+                name: "hinge",
                 default: DefaultParamValue::Number(10.0),
                 constraint: ParamConstraint::number_min(0.0),
             },

--- a/src/writer/vegalite/layer.rs
+++ b/src/writer/vegalite/layer.rs
@@ -2052,46 +2052,6 @@ impl BoxplotRenderer {
         upper_whiskers["encoding"][value_var1] = y_encoding.clone();
         upper_whiskers["encoding"][value_var2] = y2_encoding.clone();
 
-        // Whisker cap hinges: tick marks at the whisker tips
-        if let Some(ParameterValue::Number(hinge_pts)) = layer.parameters.get("hinge") {
-            let hinge_size = hinge_pts * POINTS_TO_PIXELS;
-            let orient = if is_horizontal {
-                "vertical"
-            } else {
-                "horizontal"
-            };
-            let mut enco = y_encoding.clone();
-            enco["field"] = json!(value2_col);
-
-            let mut lower_hinge = create_layer(
-                &summary_prototype,
-                "lower_whisker",
-                json!({
-                    "type": "tick",
-                    "orient": orient,
-                    "size": hinge_size,
-                    "thickness": 0,
-                    "clip": true
-                }),
-            );
-            lower_hinge["encoding"][value_var1] = enco.clone();
-            layers.push(lower_hinge);
-
-            let mut upper_hinge = create_layer(
-                &summary_prototype,
-                "upper_whisker",
-                json!({
-                    "type": "tick",
-                    "orient": orient,
-                    "size": hinge_size,
-                    "thickness": 0,
-                    "clip": true
-                }),
-            );
-            upper_hinge["encoding"][value_var1] = enco;
-            layers.push(upper_hinge);
-        }
-
         // Resolve the `side` parameter. When `side != "both"`, the box and
         // median tick render at half their normal size and anchor to the
         // categorical centerline so they only occupy one side of each band.
@@ -2199,11 +2159,88 @@ impl BoxplotRenderer {
                 size_key: box_size,
             }),
         );
-        median_line["encoding"][value_var1] = y_encoding;
+        median_line["encoding"][value_var1] = y_encoding.clone();
         apply_side_shift(&mut median_line);
 
         layers.push(lower_whiskers);
         layers.push(upper_whiskers);
+
+        // Whisker cap hinges: tick marks at the whisker tips
+        if let Some(ParameterValue::Number(hinge_pts)) = layer.parameters.get("hinge") {
+            let hinge_size = if half_side {
+                hinge_pts * POINTS_TO_PIXELS / 2.0
+            } else {
+                hinge_pts * POINTS_TO_PIXELS
+            };
+            let orient = if is_horizontal {
+                "vertical"
+            } else {
+                "horizontal"
+            };
+
+            let hinge_mark = json!({
+                "type": "tick",
+                "orient": orient,
+                "size": hinge_size,
+                "thickness": 0,
+                "clip": true
+            });
+
+            let mut enco = y_encoding.clone();
+            enco["field"] = json!(value2_col);
+
+            let mut lower_hinge =
+                create_layer(&summary_prototype, "lower_whisker", hinge_mark.clone());
+            lower_hinge["encoding"][value_var1] = enco.clone();
+            if let Some(Value::Object(ref mut enc)) = lower_hinge.get_mut("encoding") {
+                enc.remove(value_var2);
+            }
+
+            let mut upper_hinge = create_layer(&summary_prototype, "upper_whisker", hinge_mark);
+            upper_hinge["encoding"][value_var1] = enco;
+            if let Some(Value::Object(ref mut enc)) = upper_hinge.get_mut("encoding") {
+                enc.remove(value_var2);
+            }
+
+            // When half_side, shift the hinge tick toward the chosen side
+            // using the offset channel. Convert the pixel shift to a band
+            // fraction via bandwidth() so it uses the same scale as dodge.
+            if half_side {
+                let sign = if side_positive { 1.0 } else { -1.0 };
+                let hinge_offset_col = "__ggsql_hinge_offset__";
+                let calc_expr = format!(
+                    "(datum[\"{base}\"] != null ? datum[\"{base}\"] : 0) + {sign} * {px} / bandwidth('{axis}')",
+                    base = base_offset_col,
+                    sign = sign,
+                    px = hinge_size / 2.0,
+                    axis = axis,
+                );
+                let apply_hinge_offset = |layer_spec: &mut Value| {
+                    let existing = layer_spec
+                        .get("transform")
+                        .and_then(|t| t.as_array())
+                        .cloned()
+                        .unwrap_or_default();
+                    let mut transforms = existing;
+                    transforms.push(json!({
+                        "calculate": calc_expr,
+                        "as": hinge_offset_col,
+                    }));
+                    layer_spec["transform"] = json!(transforms);
+                    layer_spec["encoding"][offset_channel] = json!({
+                        "field": hinge_offset_col,
+                        "type": "quantitative",
+                        "scale": {"domain": [-0.5, 0.5]},
+                    });
+                };
+                apply_hinge_offset(&mut lower_hinge);
+                apply_hinge_offset(&mut upper_hinge);
+            }
+
+            layers.push(lower_hinge);
+            layers.push(upper_hinge);
+        }
+
         layers.push(box_part);
         layers.push(median_line);
 

--- a/src/writer/vegalite/layer.rs
+++ b/src/writer/vegalite/layer.rs
@@ -2052,6 +2052,46 @@ impl BoxplotRenderer {
         upper_whiskers["encoding"][value_var1] = y_encoding.clone();
         upper_whiskers["encoding"][value_var2] = y2_encoding.clone();
 
+        // Whisker cap hinges: tick marks at the whisker tips
+        if let Some(ParameterValue::Number(hinge_pts)) = layer.parameters.get("hinge") {
+            let hinge_size = hinge_pts * POINTS_TO_PIXELS;
+            let orient = if is_horizontal {
+                "vertical"
+            } else {
+                "horizontal"
+            };
+            let mut enco = y_encoding.clone();
+            enco["field"] = json!(value2_col);
+
+            let mut lower_hinge = create_layer(
+                &summary_prototype,
+                "lower_whisker",
+                json!({
+                    "type": "tick",
+                    "orient": orient,
+                    "size": hinge_size,
+                    "thickness": 0,
+                    "clip": true
+                }),
+            );
+            lower_hinge["encoding"][value_var1] = enco.clone();
+            layers.push(lower_hinge);
+
+            let mut upper_hinge = create_layer(
+                &summary_prototype,
+                "upper_whisker",
+                json!({
+                    "type": "tick",
+                    "orient": orient,
+                    "size": hinge_size,
+                    "thickness": 0,
+                    "clip": true
+                }),
+            );
+            upper_hinge["encoding"][value_var1] = enco;
+            layers.push(upper_hinge);
+        }
+
         // Resolve the `side` parameter. When `side != "both"`, the box and
         // median tick render at half their normal size and anchor to the
         // categorical centerline so they only occupy one side of each band.

--- a/src/writer/vegalite/layer.rs
+++ b/src/writer/vegalite/layer.rs
@@ -1760,11 +1760,11 @@ impl GeomRenderer for RangeRenderer {
         _prepared: &PreparedData,
         context: &RenderContext,
     ) -> Result<Vec<Value>> {
-        // Get width parameter (in points)
-        let width = if let Some(ParameterValue::Number(num)) = layer.parameters.get("width") {
+        // Get hinge parameter (in points)
+        let width = if let Some(ParameterValue::Number(num)) = layer.parameters.get("hinge") {
             (*num) * POINTS_TO_PIXELS
         } else {
-            // If no width specified, return just the main error bar without hinges
+            // If no hinge specified, return just the main error bar without hinges
             return Ok(vec![layer_spec]);
         };
 


### PR DESCRIPTION
This PR aims to fix #437 and #438.

Briefly, instead of the parameter name being `width`, it is now `hinge`.
Boxplots also get a `hinge` parameters to draw on top of the whisker ends.
When `side != 'both'`, the hinge is only displayed at one side at half-size.
