### PR TITLE
Avoid the toolchain toml

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -38,17 +38,18 @@ jobs:
         run: sudo apt-get install -y protobuf-compiler
 
       - name: Install Rust
-        # 1.86 is the MSRV (pinned via rust-toolchain.toml, see /CLAUDE.md). Plain
-        # `cargo` resolves to it. fmt, clippy and the library build run on 1.86 to
-        # guarantee the shipped crate builds there.
+        # 1.86 is the MSRV (declared as `rust-version` in /Cargo.toml, see
+        # /CLAUDE.md); this sets it as the default toolchain so plain `cargo`
+        # uses it. fmt, clippy and the library build run on 1.86 to guarantee
+        # the shipped crate builds there.
         uses: dtolnay/rust-toolchain@1.86.0
 
       - name: Install Rust (test toolchain)
         # The experimental `adbc` feature's test path pulls `adbc_datafusion` →
         # `datafusion` ≥53.1.0, which requires rustc ≥1.88. Steps that compile
         # tests/dev-dependencies use this newer toolchain via `cargo +stable`.
-        # Installing it here does not change the default — rust-toolchain.toml
-        # keeps plain `cargo` on 1.86.
+        # Installing it here does not change the default — plain `cargo` stays
+        # on 1.86.
         run: rustup toolchain install stable --profile minimal
 
       - name: Caching
@@ -65,8 +66,9 @@ jobs:
         run: cargo clippy -- -D warnings
 
       - name: Install wasm-pack
-        # Compile the tool itself on stable; the actual wasm build below still
-        # runs on the pinned 1.86 toolchain.
+        # `cargo install` runs at the repo root, where 1.86 is the default;
+        # `+stable` builds the tool on the newer toolchain. The actual wasm build
+        # below runs in ggsql-wasm/, whose nested rust-toolchain.toml selects stable.
         run: cargo +stable install wasm-pack
 
       - name: Build library (MSRV 1.86)

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -43,6 +43,8 @@ jobs:
         # uses it. fmt, clippy and the library build run on 1.86 to guarantee
         # the shipped crate builds there.
         uses: dtolnay/rust-toolchain@1.86.0
+        with:
+          components: rustfmt, clippy
 
       - name: Install Rust (test toolchain)
         # The experimental `adbc` feature's test path pulls `adbc_datafusion` →

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -37,15 +37,15 @@ jobs:
         run: sudo apt-get install -y unixodbc-dev
 
       - name: Install Rust
-        # 1.86 is the MSRV (see /CLAUDE.md); the Jupyter kernel build below runs
-        # on it. Plain `cargo` resolves to 1.86 via rust-toolchain.toml.
+        # 1.86 is the MSRV (see /CLAUDE.md); this is the default toolchain, and
+        # the Jupyter kernel build below runs on it.
         uses: dtolnay/rust-toolchain@1.86.0
 
       - name: Install Rust (wasm toolchain)
-        # The wasm build is exempt from the 1.86 pin (R doesn't use wasm); some
+        # The wasm build is exempt from the 1.86 MSRV (R doesn't use wasm); some
         # wasm-only deps need a newer rustc. Installing stable here does not
-        # change the default — rust-toolchain.toml keeps plain `cargo` on 1.86,
-        # and ggsql-wasm/rust-toolchain.toml selects stable for the wasm build.
+        # change the default — plain `cargo` stays on 1.86, and
+        # ggsql-wasm/rust-toolchain.toml selects stable for the wasm build.
         run: rustup toolchain install stable --profile minimal
 
       - name: Caching

--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -476,21 +476,19 @@ jobs:
         run: npm install -g tree-sitter-cli
 
       - name: Install Rust toolchain
-        # The wasm build is exempt from the 1.86 MSRV pin (R doesn't use wasm);
-        # some wasm-only deps need a newer rustc. ggsql-wasm/rust-toolchain.toml
-        # selects stable for the actual build.
+        # This job only builds wasm, which is exempt from the 1.86 MSRV (R
+        # doesn't use wasm) and needs a newer rustc, so the whole job runs on
+        # stable. ggsql-wasm/rust-toolchain.toml also selects stable for the build.
         uses: dtolnay/rust-toolchain@stable
 
       - name: Install LLVM
         run: sudo apt-get install -y llvm
 
       - name: Install wasm-pack
-        # `cargo install` runs at the repo root, where rust-toolchain.toml pins
-        # 1.86; `+stable` builds these tools on the newer toolchain instead.
-        run: cargo +stable install wasm-pack
+        run: cargo install wasm-pack
 
       - name: Install wasm-opt
-        run: cargo +stable install wasm-opt
+        run: cargo install wasm-opt
 
       - name: Build WASM package
         run: ./ggsql-wasm/build-wasm.sh

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,6 +48,8 @@ For details — module layout, traits, where extension points live — see [`src
 
 ## Building
 
+**Prerequisite: `tree-sitter-cli`.** Any Rust build regenerates the parser from `grammar.js` via `tree-sitter-ggsql`'s build script, which runs `tree-sitter generate` and **fails if `tree-sitter-cli` is not on `PATH`**. Install it once with `npm install -g tree-sitter-cli`. To build against the committed `tree-sitter-ggsql/src/parser.c` without the CLI (e.g. if you're not touching the grammar), set `GGSQL_SKIP_GENERATE=1`.
+
 ```sh
 # Rust workspace (default members: tree-sitter-ggsql, src, ggsql-cli, ggsql-jupyter)
 cargo build --workspace
@@ -71,11 +73,13 @@ cd tree-sitter-ggsql && npx tree-sitter generate
 
 ### Rust version (MSRV)
 
-The toolchain is **pinned to Rust 1.86** (`rust-toolchain.toml` + `rust-version` in `/Cargo.toml`). This is the maximum Rust version CRAN ships, and the R bindings must build against it — **only bump it when CRAN does.** Setting `rust-version` also turns on clippy's MSRV-aware lints, so accidental use of a newer std API fails `clippy`/build with a clear message instead of a cryptic `E0658`.
+The MSRV is **Rust 1.86**, declared as `rust-version` in `/Cargo.toml`. This is the maximum Rust version CRAN ships, and the R bindings must build against it — **only bump it when CRAN does.** `rust-version` also turns on clippy's MSRV-aware lints, so accidental use of a newer std API is flagged by `clippy` with a clear message instead of a cryptic `E0658`.
 
-Two things are exempt from the pin:
+There is deliberately **no root `rust-toolchain.toml`**: pinning the toolchain to 1.86 would force local `cargo test`/rust-analyzer onto 1.86, where the `adbc` test path can't build (see below). Instead, the MSRV is *enforced in CI* — `build.yaml` installs 1.86 as the default toolchain and runs fmt, clippy and the library build on it. Locally, use your normal toolchain; run `cargo +1.86 build` if you want to check MSRV compatibility directly.
 
-- **The `adbc` test path.** The experimental `adbc` feature depends (dev-only) on `adbc_datafusion` → `datafusion` ≥53.1.0, which requires rustc ≥1.88. The shipped library still builds on 1.86; only the test / `--all-targets` build needs the newer toolchain. CI (`build.yaml`) runs fmt, clippy and the library build on 1.86, and runs the test-compiling steps with `cargo +stable`.
+Two things are exempt from the 1.86 MSRV:
+
+- **The `adbc` test path.** The experimental `adbc` feature depends (dev-only) on `adbc_datafusion` → `datafusion` ≥53.1.0, which requires rustc ≥1.88. The shipped library still builds on 1.86 (it uses only `adbc_core`); only the test / `--all-targets` build pulls `datafusion`. CI runs the test-compiling steps with `cargo +stable`.
 - **The wasm bindings (`ggsql-wasm`).** R doesn't use wasm, and some wasm-only dependencies require a newer rustc, so the crate has no `rust-version` and a nested `ggsql-wasm/rust-toolchain.toml` selects **stable** for any build done from that directory (`./build-wasm.sh`, `wasm-pack`, `library/`).
 
 Cross-platform installers (NSIS / MSI / DMG / Deb): see [`INSTALLERS.md`](INSTALLERS.md). Releases are tag-driven via `.github/workflows/`.

--- a/ggsql-wasm/CLAUDE.md
+++ b/ggsql-wasm/CLAUDE.md
@@ -31,7 +31,7 @@ ggsql-wasm/
 
 ## Toolchain
 
-- **Rust stable, not the workspace 1.86 MSRV.** The rest of the workspace is pinned to 1.86 for the R/CRAN bindings (see [`/CLAUDE.md`](../CLAUDE.md)), but R doesn't use wasm and some wasm-only deps need a newer rustc. A nested [`rust-toolchain.toml`](rust-toolchain.toml) selects stable for any build run from this directory; this crate has no `rust-version`. In CI the wasm tool installs (`cargo install wasm-pack`/`wasm-opt`) run at the repo root, so they use `cargo +stable` to avoid the 1.86 pin.
+- **Rust stable, not the workspace 1.86 MSRV.** The rest of the workspace targets the 1.86 MSRV for the R/CRAN bindings (see [`/CLAUDE.md`](../CLAUDE.md)), but R doesn't use wasm and some wasm-only deps need a newer rustc. A nested [`rust-toolchain.toml`](rust-toolchain.toml) selects stable for any build run from this directory; this crate has no `rust-version`. In CI, the multi-purpose jobs (`build.yaml`, `publish.yaml`) default to 1.86, so their wasm tool installs (`cargo install wasm-pack`/`wasm-opt`, run at the repo root) use `cargo +stable`; the wasm-only release job runs entirely on stable.
 - Rust target `wasm32-unknown-unknown` and [`wasm-pack`](https://rustwasm.github.io/wasm-pack/) for compilation.
 - A clang/llvm with wasm backend support (the build script verifies this with a one-line probe).
 - `wasm-opt` (from binaryen) for the `-Oz` optimization step.

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,6 +1,0 @@
-# Pinned to CRAN's maximum supported Rust version so the R bindings keep
-# building. Only bump this (and `rust-version` in Cargo.toml) when CRAN raises
-# the Rust version it ships. See /CLAUDE.md.
-[toolchain]
-channel = "1.86"
-components = ["rustfmt", "clippy"]


### PR DESCRIPTION
This PR fixes a regression from #475 that prevented local compilation

We remove the rust-toolchain.toml enforcement and instead set these in the CI