### PR TITLE
Jupyter: Acknowledge SIGINT without exiting

### DIFF
--- a/ggsql-jupyter/src/kernel.rs
+++ b/ggsql-jupyter/src/kernel.rs
@@ -137,17 +137,14 @@ impl KernelServer {
                     }
                 }
                 _ = tokio::signal::ctrl_c() => {
-                    tracing::warn!("Received SIGINT, shutting down gracefully");
-                    // Send a final idle status before exiting
-                    // Note: We don't have a parent message here, so we'll send without one
-                    let msg = self.create_message(
-                        "status",
-                        json!({"execution_state": "idle"}),
-                        None,
-                    );
-                    let zmq_msg = self.serialize_message_with_topic(&msg, "status")?;
-                    let _ = self.iopub.send(zmq_msg).await;
-                    break;
+                    // With `interrupt_mode: "signal"`, the frontend sends SIGINT to
+                    // interrupt a running cell, not to stop the kernel. Emit a busy
+                    // -> idle pair to acknowledge the interrupt.
+                    // TODO: When cell execution becomes async, cancel any in-flight
+                    //       request here instead.
+                    tracing::debug!("Received SIGINT; acknowledging.");
+                    self.send_status_initial("busy").await?;
+                    self.send_status_initial("idle").await?;
                 }
             }
         }


### PR DESCRIPTION
In the Jupyter kernel,  we use `interrupt_mode: "signal"`, so the frontend sends SIGINT to interrupt a running cell, not to exit.

Previously, we quit on SIGINT, leading to interrupts killing the kernel:

<img width="349" height="123" alt="Screenshot 2026-07-01 at 09 00 30" src="https://github.com/user-attachments/assets/deb1be0e-30c6-4886-a68a-ba2a17453504" />

With this change we handle the SIGINT by immediately acknowledging we are idle and then continue running, so sending Ctrl-C in Positron acts as expected.

<img width="364" height="119" alt="Screenshot 2026-07-01 at 08 59 49" src="https://github.com/user-attachments/assets/4a623fd4-5cd7-4a5f-a403-fa82938e9a18" />

Shutting down and restarting the kernel still works, because that uses a different mechanism.

In the future, we will likely switch to asynchronous cell execution. At that point we should cancel any in-flight async requests before acknowledging we are idle.