### PR TITLE
Complete Vega-Lite geom and guide rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 ## [Unreleased]
 
+### Added
+
+- Support `LABEL legend => 'left' | 'right' | 'top' | 'bottom' | 'none'`
+  (or `null`) for plot-wide legend placement and suppression.
+- Allow rule layers to carry a `label` aesthetic, rendered at the trailing
+  edge of the reference line by the Vega-Lite writer.
+
+### Fixed
+
+- Render `DRAW arrow` as a line segment with a directional arrowhead in the
+  Vega-Lite writer instead of falling back to a point mark.
+
 ## 0.4.1 - 2026-06-22
 
 ### Changed

--- a/doc/syntax/clause/label.qmd
+++ b/doc/syntax/clause/label.qmd
@@ -17,6 +17,8 @@ There are a few additional labels beside the aesthetics that govern the differen
 
 * `title`: The main title of the plot
 * `subtitle`: An additional, often longer and more descriptive, title beneath the main title
+* `legend`: Place all legends at `'left'`, `'right'`, `'top'`, or `'bottom'`.
+  Use `'none'` or `null` to suppress them.
 * `caption`: A string placed below the plot, often used to add additional information about the data source etc. Currently not possible as our only writer (Vega-Lite) doesn't support it. Will be available as new writers appear.
 
 ## Automatic labelling logic

--- a/doc/syntax/layer/type/rule.qmd
+++ b/doc/syntax/layer/type/rule.qmd
@@ -22,6 +22,7 @@ The following aesthetics are recognised by the rule layer.
 * `opacity`: The opacity of the line
 * `linewidth`: The width of the line
 * `linetype`: The type of the line, i.e. the dashing pattern
+* `label`: Optional text placed at the trailing edge of the reference line.
 
 ## Settings
 * `position`: Position adjustment. One of `'identity'` (default), `'stack'`, `'dodge'`, or `'jitter'`
@@ -56,7 +57,7 @@ VISUALISE
 DRAW line 
   MAPPING date AS x, temperature AS y
 PLACE rule 
-  SETTING y => 70
+  SETTING y => 70, label => 'Target'
 ```
 
 Add a vertical line to mark a specific value:

--- a/src/Cargo.toml
+++ b/src/Cargo.toml
@@ -68,7 +68,11 @@ parquet = ["dep:parquet"]
 sqlite = ["dep:rusqlite"]
 adbc = ["dep:adbc_core"]
 odbc = ["dep:toml_edit", "dep:libloading"]
-spatial = ["dep:geozero", "rusqlite?/load_extension"]
+# Spatial plot preparation only needs geozero. The SQLite reader already
+# enables rusqlite's load_extension feature when `sqlite` is selected; keeping
+# that optional dependency out of this feature avoids libsqlite3 link conflicts
+# for consumers that provide another SQLite-backed subsystem.
+spatial = ["dep:geozero"]
 vegalite = []
 builtin-data = []
 all-readers = ["duckdb", "sqlite", "odbc"]

--- a/src/plot/layer/geom/rule.rs
+++ b/src/plot/layer/geom/rule.rs
@@ -29,6 +29,7 @@ impl GeomTrait for Rule {
                 ("linewidth", DefaultAestheticValue::Number(1.0)),
                 ("opacity", DefaultAestheticValue::Number(1.0)),
                 ("linetype", DefaultAestheticValue::String("solid")),
+                ("label", DefaultAestheticValue::Null),
             ],
         }
     }

--- a/src/writer/vegalite/encoding.rs
+++ b/src/writer/vegalite/encoding.rs
@@ -915,12 +915,57 @@ fn build_column_encoding(
         insert_legend_property(&mut encoding, "type", json!("gradient"));
     }
 
+    apply_plot_legend_preference(&mut encoding, aesthetic, ctx.spec);
+
     // Hide axis for dummy columns
     if is_dummy {
         encoding["axis"] = Value::Null;
     }
 
     Ok(encoding)
+}
+
+/// Apply the plot-wide legend preference carried by `LABEL legend`.
+///
+/// This keeps guide placement in the ggsql Plot/Writer boundary instead of
+/// requiring each downstream renderer to mutate Vega-Lite output. `none`
+/// suppresses every material guide; the four cardinal values map directly to
+/// Vega-Lite's legend orientation.
+fn apply_plot_legend_preference(encoding: &mut Value, aesthetic: &str, spec: &Plot) {
+    if !matches!(
+        aesthetic,
+        "color"
+            | "colour"
+            | "fill"
+            | "stroke"
+            | "opacity"
+            | "size"
+            | "shape"
+            | "linetype"
+            | "linewidth"
+    ) {
+        return;
+    }
+
+    let preference = spec
+        .labels
+        .as_ref()
+        .and_then(|labels| labels.labels.get("legend"));
+    match preference {
+        Some(None) => encoding["legend"] = Value::Null,
+        Some(Some(value)) if value.eq_ignore_ascii_case("none") => {
+            encoding["legend"] = Value::Null;
+        }
+        Some(Some(value))
+            if matches!(
+                value.to_ascii_lowercase().as_str(),
+                "left" | "right" | "top" | "bottom"
+            ) =>
+        {
+            insert_legend_property(encoding, "orient", json!(value.to_ascii_lowercase()));
+        }
+        _ => {}
+    }
 }
 
 /// Build encoding for a literal aesthetic value

--- a/src/writer/vegalite/layer.rs
+++ b/src/writer/vegalite/layer.rs
@@ -43,11 +43,11 @@ pub fn geom_to_mark(geom: &Geom) -> Value {
         GeomType::Boxplot => "boxplot",
         GeomType::Text => "text",
         GeomType::Segment => "rule",
+        GeomType::Arrow => "rule",
         GeomType::Smooth => "line",
         GeomType::Rule => "rule",
         GeomType::Range => "rule",
         GeomType::Spatial => "geoshape",
-        _ => "point", // Default fallback
     };
     json!({
         "type": mark_type,
@@ -853,6 +853,103 @@ impl GeomRenderer for RuleRenderer {
 
         Ok(())
     }
+
+    fn finalize(
+        &self,
+        mut layer_spec: Value,
+        layer: &Layer,
+        _data_key: &str,
+        _prepared: &PreparedData,
+        context: &RenderContext,
+    ) -> Result<Vec<Value>> {
+        let has_label = matches!(
+            layer.mappings.get("label"),
+            Some(AestheticValue::Literal(ParameterValue::String(_)))
+                | Some(AestheticValue::Column { .. })
+                | Some(AestheticValue::AnnotationColumn { .. })
+        );
+        if !has_label {
+            return Ok(vec![layer_spec]);
+        }
+
+        if matches!(
+            layer.parameters.get("densified"),
+            Some(ParameterValue::Boolean(true))
+        ) {
+            return Ok(vec![layer_spec]);
+        }
+
+        let mut label_spec = layer_spec.clone();
+        let shaft_encoding = layer_spec
+            .get_mut("encoding")
+            .and_then(Value::as_object_mut)
+            .ok_or_else(|| {
+                GgsqlError::WriterError("Rule layer is missing its Vega-Lite encoding".to_string())
+            })?;
+        shaft_encoding.remove("text");
+
+        let label_encoding = label_spec
+            .get_mut("encoding")
+            .and_then(Value::as_object_mut)
+            .ok_or_else(|| {
+                GgsqlError::WriterError(
+                    "Labeled rule layer is missing its Vega-Lite encoding".to_string(),
+                )
+            })?;
+        if let Some(stroke) = label_encoding.remove("stroke") {
+            label_encoding.insert("fill".to_string(), stroke);
+        }
+        label_encoding.remove("strokeWidth");
+        label_encoding.remove("strokeDash");
+
+        let (pos1, pos1_end, _, pos2, pos2_end, _) = &context.channels;
+
+        let label_mark = if label_encoding.contains_key(pos2.as_str())
+            && !label_encoding.contains_key(pos1.as_str())
+        {
+            label_encoding.remove(pos1_end.as_str());
+            label_encoding.remove(pos2_end.as_str());
+            label_encoding.insert(pos1.clone(), json!({"value": "width"}));
+            json!({
+                "type": "text",
+                "align": "right",
+                "baseline": "bottom",
+                "dx": -4,
+                "dy": -4,
+                "clip": true
+            })
+        } else if label_encoding.contains_key(pos1.as_str())
+            && !label_encoding.contains_key(pos2.as_str())
+        {
+            label_encoding.remove(pos1_end.as_str());
+            label_encoding.remove(pos2_end.as_str());
+            label_encoding.insert(pos2.clone(), json!({"value": 0}));
+            json!({
+                "type": "text",
+                "align": "left",
+                "baseline": "top",
+                "dx": 4,
+                "dy": 4,
+                "clip": true
+            })
+        } else {
+            // Diagonal rules already carry both endpoints. Anchor the label at
+            // the end of the resolved line.
+            move_endpoint_encoding(label_encoding, pos1, pos1_end)?;
+            move_endpoint_encoding(label_encoding, pos2, pos2_end)?;
+            json!({
+                "type": "text",
+                "align": "left",
+                "baseline": "bottom",
+                "dx": 4,
+                "dy": -4,
+                "clip": true
+            })
+        };
+        label_spec["mark"] = label_mark;
+
+        Ok(vec![layer_spec, label_spec])
+    }
 }
 
 // =============================================================================
@@ -1622,6 +1719,133 @@ impl GeomRenderer for SegmentRenderer {
 
         Ok(())
     }
+}
+
+// =============================================================================
+// Arrow Renderer
+// =============================================================================
+
+/// Renderer for arrow geom — a rule shaft plus a directional point at the end.
+///
+/// Vega-Lite has no primitive arrow mark, but its point mark supports an
+/// `arrow` symbol and the `angle` channel. Rendering both components from the
+/// same resolved layer preserves ggsql's scales, facets, material aesthetics,
+/// and source filtering without asking downstream consumers to reinterpret the
+/// plot.
+pub struct ArrowRenderer;
+
+impl GeomRenderer for ArrowRenderer {
+    fn modify_spec(
+        &self,
+        layer_spec: &mut Value,
+        _layer: &Layer,
+        _context: &RenderContext,
+    ) -> Result<()> {
+        layer_spec["mark"] = json!({
+            "type": "rule",
+            "clip": true
+        });
+        Ok(())
+    }
+
+    fn finalize(
+        &self,
+        layer_spec: Value,
+        _layer: &Layer,
+        _data_key: &str,
+        _prepared: &PreparedData,
+        context: &RenderContext,
+    ) -> Result<Vec<Value>> {
+        let mut arrowhead = layer_spec.clone();
+        arrowhead["mark"] = json!({
+            "type": "point",
+            "shape": "arrow",
+            "filled": true,
+            "size": 72,
+            "clip": true
+        });
+
+        let (pos1, pos1_end, _, pos2, pos2_end, _) = &context.channels;
+        let encoding = arrowhead
+            .get_mut("encoding")
+            .and_then(Value::as_object_mut)
+            .ok_or_else(|| {
+                GgsqlError::WriterError("Arrow layer is missing its Vega-Lite encoding".to_string())
+            })?;
+
+        move_endpoint_encoding(encoding, pos1, pos1_end)?;
+        move_endpoint_encoding(encoding, pos2, pos2_end)?;
+
+        let angle_field = "__ggsql_arrow_angle__";
+        encoding.insert(
+            "angle".to_string(),
+            json!({
+                "field": angle_field,
+                "type": "quantitative",
+                "scale": null
+            }),
+        );
+
+        // Arrowheads inherit the shaft colour. `fill` defaults to null for
+        // arrows, so use the resolved stroke channel unless the author supplied
+        // an explicit fill mapping or literal.
+        if encoding
+            .get("fill")
+            .and_then(|value| value.get("value"))
+            .is_some_and(Value::is_null)
+        {
+            if let Some(stroke) = encoding.get("stroke").cloned() {
+                encoding.insert("fill".to_string(), stroke);
+            }
+        }
+
+        let mut transforms = arrowhead
+            .get("transform")
+            .and_then(Value::as_array)
+            .cloned()
+            .unwrap_or_default();
+        let start_x = naming::aesthetic_column("pos1");
+        let start_y = naming::aesthetic_column("pos2");
+        let end_x = naming::aesthetic_column("pos1end");
+        let end_y = naming::aesthetic_column("pos2end");
+        transforms.push(json!({
+            "calculate": format!(
+                "90 - atan2(datum[{end_y:?}] - datum[{start_y:?}], \
+                 datum[{end_x:?}] - datum[{start_x:?}]) * 180 / PI"
+            ),
+            "as": angle_field
+        }));
+        arrowhead["transform"] = Value::Array(transforms);
+
+        Ok(vec![layer_spec, arrowhead])
+    }
+}
+
+fn move_endpoint_encoding(
+    encoding: &mut Map<String, Value>,
+    primary: &str,
+    secondary: &str,
+) -> Result<()> {
+    let endpoint = encoding.remove(secondary).ok_or_else(|| {
+        GgsqlError::WriterError(format!(
+            "Arrow layer is missing its '{}' endpoint encoding",
+            secondary
+        ))
+    })?;
+    let endpoint_field = endpoint.get("field").cloned().ok_or_else(|| {
+        GgsqlError::WriterError(format!(
+            "Arrow layer's '{}' endpoint encoding has no field",
+            secondary
+        ))
+    })?;
+    let primary_encoding = encoding.get_mut(primary).ok_or_else(|| {
+        GgsqlError::WriterError(format!(
+            "Arrow layer is missing its '{}' position encoding",
+            primary
+        ))
+    })?;
+    primary_encoding["field"] = endpoint_field;
+    Ok(())
 }
 
 // =============================================================================
@@ -2598,9 +2822,11 @@ pub fn get_renderer(geom: &Geom) -> Box<dyn GeomRenderer> {
         GeomType::Rule => Box::new(RuleRenderer),
         GeomType::Ribbon => Box::new(RibbonRenderer),
         GeomType::Segment => Box::new(SegmentRenderer),
+        GeomType::Arrow => Box::new(ArrowRenderer),
         GeomType::Spatial => Box::new(SpatialRenderer),
-        // All other geoms (Point, Area, Density, etc.) use the default renderer
-        _ => Box::new(DefaultRenderer),
+        GeomType::Area | GeomType::Histogram | GeomType::Density | GeomType::Smooth => {
+            Box::new(DefaultRenderer)
+        }
     }
 }
 
@@ -2608,6 +2834,104 @@ pub fn get_renderer(geom: &Geom) -> Box<dyn GeomRenderer> {
 mod tests {
     use super::*;
     use crate::plot::Parameters;
+
+    #[test]
+    fn test_arrow_renderer_emits_shaft_and_directional_head() {
+        let renderer = ArrowRenderer;
+        let layer = Layer::new(crate::plot::Geom::arrow());
+        let context = RenderContext::default_for_test();
+        let prepared = PreparedData::Single {
+            values: Vec::new(),
+            metadata: Box::new(()),
+        };
+        let prototype = json!({
+            "mark": {"type": "rule", "clip": true},
+            "transform": [{
+                "filter": {
+                    "field": naming::SOURCE_COLUMN,
+                    "equal": "test"
+                }
+            }],
+            "encoding": {
+                "x": {
+                    "field": naming::aesthetic_column("pos1"),
+                    "type": "quantitative"
+                },
+                "x2": {"field": naming::aesthetic_column("pos1end")},
+                "y": {
+                    "field": naming::aesthetic_column("pos2"),
+                    "type": "quantitative"
+                },
+                "y2": {"field": naming::aesthetic_column("pos2end")},
+                "stroke": {"value": "#123456"},
+                "fill": {"value": null}
+            }
+        });
+
+        let layers = renderer
+            .finalize(prototype, &layer, "test", &prepared, &context)
+            .unwrap();
+
+        assert_eq!(layers.len(), 2);
+        assert_eq!(layers[0]["mark"]["type"], "rule");
+        assert_eq!(layers[1]["mark"]["type"], "point");
+        assert_eq!(layers[1]["mark"]["shape"], "arrow");
+        assert_eq!(
+            layers[1]["encoding"]["x"]["field"],
+            naming::aesthetic_column("pos1end")
+        );
+        assert_eq!(
+            layers[1]["encoding"]["y"]["field"],
+            naming::aesthetic_column("pos2end")
+        );
+        assert!(layers[1]["encoding"].get("x2").is_none());
+        assert!(layers[1]["encoding"].get("y2").is_none());
+        assert_eq!(layers[1]["encoding"]["fill"]["value"], "#123456");
+        assert_eq!(
+            layers[1]["encoding"]["angle"]["field"],
+            "__ggsql_arrow_angle__"
+        );
+        assert_eq!(layers[1]["transform"].as_array().unwrap().len(), 2);
+    }
+
+    #[test]
+    fn test_rule_renderer_emits_trailing_label() {
+        let renderer = RuleRenderer;
+        let mut layer = Layer::new(crate::plot::Geom::rule());
+        layer.mappings.insert(
+            "label".to_string(),
+            AestheticValue::Literal(ParameterValue::String("Target".to_string())),
+        );
+        let context = RenderContext::default_for_test();
+        let prepared = PreparedData::Single {
+            values: Vec::new(),
+            metadata: Box::new(()),
+        };
+        let prototype = json!({
+            "mark": {"type": "rule", "clip": true},
+            "encoding": {
+                "y": {
+                    "field": naming::aesthetic_column("pos2"),
+                    "type": "quantitative"
+                },
+                "text": {"value": "Target"},
+                "stroke": {"value": "#123456"}
+            }
+        });
+
+        let layers = renderer
+            .finalize(prototype, &layer, "test", &prepared, &context)
+            .unwrap();
+
+        assert_eq!(layers.len(), 2);
+        assert_eq!(layers[0]["mark"]["type"], "rule");
+        assert!(layers[0]["encoding"].get("text").is_none());
+        assert_eq!(layers[1]["mark"]["type"], "text");
+        assert_eq!(layers[1]["mark"]["align"], "right");
+        assert_eq!(layers[1]["encoding"]["x"]["value"], "width");
+        assert_eq!(layers[1]["encoding"]["text"]["value"], "Target");
+        assert_eq!(layers[1]["encoding"]["fill"]["value"], "#123456");
+    }
 
     #[test]
     fn test_violin_detail_encoding() {

--- a/src/writer/vegalite/mod.rs
+++ b/src/writer/vegalite/mod.rs
@@ -1593,6 +1593,66 @@ mod tests {
     }
 
     #[test]
+    fn test_plot_legend_label_controls_guide_orientation_and_visibility() {
+        let writer = VegaLiteWriter::new();
+        let make_spec = |preference: Option<&str>| {
+            let mut spec = Plot::new();
+            spec.layers.push(
+                Layer::new(Geom::point())
+                    .with_aesthetic(
+                        "pos1".to_string(),
+                        AestheticValue::standard_column("x".to_string()),
+                    )
+                    .with_aesthetic(
+                        "pos2".to_string(),
+                        AestheticValue::standard_column("y".to_string()),
+                    )
+                    .with_aesthetic(
+                        "fill".to_string(),
+                        AestheticValue::standard_column("group".to_string()),
+                    ),
+            );
+            spec.labels = Some(Labels {
+                labels: HashMap::from([("legend".to_string(), preference.map(str::to_string))]),
+            });
+            transform_spec(&mut spec);
+            spec
+        };
+        let data = || {
+            df! {
+                "x" => vec![1, 2],
+                "y" => vec![3, 4],
+                "group" => vec!["a", "b"],
+            }
+            .unwrap()
+        };
+
+        let bottom: Value = serde_json::from_str(
+            &writer
+                .write(&make_spec(Some("bottom")), &wrap_data(data()))
+                .unwrap(),
+        )
+        .unwrap();
+        assert_eq!(
+            bottom["layer"][0]["encoding"]["fill"]["legend"]["orient"],
+            "bottom"
+        );
+
+        let hidden: Value = serde_json::from_str(
+            &writer
+                .write(&make_spec(Some("none")), &wrap_data(data()))
+                .unwrap(),
+        )
+        .unwrap();
+        assert!(hidden["layer"][0]["encoding"]["fill"]["legend"].is_null());
+
+        let suppressed: Value =
+            serde_json::from_str(&writer.write(&make_spec(None), &wrap_data(data())).unwrap())
+                .unwrap();
+        assert!(suppressed["layer"][0]["encoding"]["fill"]["legend"].is_null());
+    }
+
+    #[test]
     fn test_labels_newline_splitting() {
         use crate::execute;
         use crate::reader::DuckDBReader;


### PR DESCRIPTION
Adds first-class Vega-Lite rendering for arrow geoms, including directional heads, and makes geom dispatch exhaustive so future additions cannot silently fall through. Also adds plot-wide legend placement/suppression through LABEL legend and optional trailing labels for rule annotations.