### PR TITLE
Add language icon, New File entry, and .sql file support

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -8,6 +8,9 @@
             "args": [
                 "--extensionDevelopmentPath=${workspaceFolder}/ggsql-vscode"
             ],
+            "outFiles": [
+                "${workspaceFolder}/ggsql-vscode/out/**/*.js"
+            ],
             "preLaunchTask": "build-ggsql-vscode"
         }
     ]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@
 - The VS Code / Positron extension now ships a language icon that renders in the
   session picker, editor tabs and the Explorer. It previously pointed at a file
   that did not exist, which left the icon blank.
+- In plain VS Code, the extension no longer offers run buttons, keybindings or
+  Command Palette entries for commands that need the Positron runtime and so
+  had no handler there.
 
 ## 0.4.1 - 2026-06-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 ## [Unreleased]
 
+### Added
+
+- The VS Code / Positron extension now offers its "Source Current File" button
+  and code cells in plain `.sql` files, so existing SQL can be run against a
+  ggsql kernel without renaming it. `.sql` files keep their usual SQL syntax
+  highlighting; to get ggsql highlighting as well, map them to the `ggsql`
+  language type with `files.associations`, which the extension points out the
+  first time a `.sql` file is opened. The new `ggsql.enableSqlFiles` setting
+  turns the whole behaviour off.
+- The VS Code / Positron extension contributes a "ggsql File" entry to the
+  New File dialog.
+
+### Fixed
+
+- The VS Code / Positron extension now ships a language icon that renders in the
+  session picker, editor tabs and the Explorer. It previously pointed at a file
+  that did not exist, which left the icon blank.
+
 ## 0.4.1 - 2026-06-22
 
 ### Changed

--- a/doc/get_started/tooling/positron-vscode.qmd
+++ b/doc/get_started/tooling/positron-vscode.qmd
@@ -41,6 +41,26 @@ To create a cell, simply add a line with `-- %%` between blocks of code in your 
 
 ![](./screenshots/positron-cells.png)
 
+## Using ggsql with `.sql` files {#sql-files}
+
+ggsql is a superset of SQL, so the ggsql console can execute a plain SQL query. The extension offers the "Source Current File" button and code cells in `.sql` files as well as `.gsql` files, which means you can run SQL you already have against a ggsql kernel without renaming anything.
+
+By default `.sql` files keep their usual SQL syntax highlighting, so any other database tooling you have installed continues to work as before. If you would rather give `.sql` files the full ggsql treatment, including highlighting for `VISUALISE` and the other ggsql clauses, map them to the `ggsql` language type:
+
+```json
+"files.associations": {
+    "*.sql": "ggsql"
+}
+```
+
+The extension points you at this setting when you open a `.sql` file, but it never changes the setting for you. Mapping `*.sql` affects every `.sql` file you open, so the choice is left to you. Add it to a single workspace rather than your user settings if you only want it for one project, and use "Don't show again" on the notification if you would rather not be reminded.
+
+If you use `.sql` files with other database tooling and would prefer the extension leave them alone entirely, turn the run buttons and cells off:
+
+```json
+"ggsql.enableSqlFiles": false
+```
+
 ## Database connections
 
 By default, ggsql starts in the Positron console with an empty in-memory duckdb database connection. A "magic" comment can be used to initiate a different database connection after the session has launched, which can be either a comment in your source file or invoked directly in the console.

--- a/ggsql-vscode/CLAUDE.md
+++ b/ggsql-vscode/CLAUDE.md
@@ -88,7 +88,15 @@ The extension declares `contributes.languageRuntimes` for `ggsql` (see `package.
 2. Registers it as a Positron language runtime so `▶ Run` and the Console route to the kernel.
 3. Routes plot output to Positron's Plot pane via metadata coming back from the kernel (`output_location: "plot"`).
 
-Outside Positron, the same commands fall back to writing query output to the active terminal.
+Outside Positron there is no way to execute a query: `activate()` returns early, so every command that runs code stays unregistered. To avoid offering actions that cannot work, everything execution-related gates on Positron's built-in **`isPositron`** context key ([extension development docs](https://positron.posit.co/extension-development.html#option-1-context-keys)):
+
+- the two `editor/title/run` buttons
+- the three keybindings
+- the five run commands, hidden from the Command Palette via a `commandPalette` menu entry
+
+`isPositron` is declared with a default of `true`, so it is correct in Positron from startup with no code and no activation-order window. In VS Code the key is never declared, so it evaluates falsy. Prefer it over a hand-rolled `setContext` key for anything purely declarative; the Positron API (`tryAcquirePositronApi`) is the right check when the code needs the API object itself.
+
+Anything that does *not* need the runtime (`ggsql.createNewFile`, `ggsql.resetSqlAssociationPrompt`, syntax highlighting) is registered before the early return and works in plain VS Code. Add new commands on the correct side of that line, and gate them if they execute code.
 
 ## Settings
 

--- a/ggsql-vscode/CLAUDE.md
+++ b/ggsql-vscode/CLAUDE.md
@@ -34,7 +34,9 @@ ggsql-vscode/
 
 ## File extensions and language ID
 
-`package.json` registers `id: ggsql` for `.ggsql`, `.ggsql.sql`, and `.gsql`. The TextMate grammar at `syntaxes/ggsql.tmLanguage.json` provides tokenization. Tree-sitter highlights — used by editors that prefer the grammar package directly — live in [`/tree-sitter-ggsql/queries/highlights.scm`](../tree-sitter-ggsql/queries/highlights.scm).
+`package.json` registers `id: ggsql` for `.gsql`, `.ggsql`, and `.ggsql.sql`. **Order matters:** the first entry is the primary extension, and it is what the workbench suggests when saving an untitled ggsql document (`textFileService.suggestFilename` uses `extensions.at(0)`). `.gsql` is first to match the documented extension in [`/doc/get_started/tooling/positron-vscode.qmd`](../doc/get_started/tooling/positron-vscode.qmd).
+
+The TextMate grammar at `syntaxes/ggsql.tmLanguage.json` provides tokenization. Tree-sitter highlights — used by editors that prefer the grammar package directly — live in [`/tree-sitter-ggsql/queries/highlights.scm`](../tree-sitter-ggsql/queries/highlights.scm).
 
 ## Commands and keybindings
 
@@ -47,8 +49,11 @@ Declared in `package.json` and wired up in `extension.ts`:
 | `ggsql.runNextCell` | — | Run the next cell |
 | `ggsql.runCellsAbove` | — | Run all cells above the cursor |
 | `ggsql.sourceCurrentFile` | — | Run the entire file (also exposed as the editor "Run" button) |
+| `ggsql.createNewFile` | — | Open a new untitled ggsql document (also in the New File dialog) |
 
 Cells are detected by `cellParser.ts`; `codelens.ts` puts a CodeLens above each cell.
+
+`ggsql.createNewFile` is contributed to the `file/newFile` menu under its own `ggsql` group, so the New File dialog lists it beneath the built-in File and Notebook sections rather than alongside them. It is registered before the Positron API check in `extension.ts`, since opening an untitled document does not need Positron.
 
 ## Positron integration
 

--- a/ggsql-vscode/CLAUDE.md
+++ b/ggsql-vscode/CLAUDE.md
@@ -55,6 +55,31 @@ Cells are detected by `cellParser.ts`; `codelens.ts` puts a CodeLens above each 
 
 `ggsql.createNewFile` is contributed to the `file/newFile` menu under its own `ggsql` group, so the New File dialog lists it beneath the built-in File and Notebook sections rather than alongside them. It is registered before the Positron API check in `extension.ts`, since opening an untitled document does not need Positron.
 
+## Attaching to `.sql` files
+
+ggsql is a SQL superset, so the kernel can execute a plain `.sql` file. Rather than claiming the `.sql` file association, the extension attaches its run affordances to documents already tokenized as `sql`:
+
+- [`src/languages.ts`](src/languages.ts) is the single source of truth. `isGgsqlDocument()` decides whether ggsql will act on a document; every command guard, decoration and context key routes through it. Add new language-scoped behaviour there rather than comparing `languageId` inline.
+- `CELL_LANGUAGE_IDS` registers the CodeLens provider for both ids. The provider gates on `isGgsqlDocument()` at request time and fires `onDidChangeCodeLenses` when `ggsql.enableSqlFiles` changes, so the setting takes effect without re-registering.
+- The `editor/title/run` `when` clauses gate on `config.ggsql.enableSqlFiles` directly, so no context key is needed for the buttons.
+
+Why not claim `.sql` in `contributes.languages`: extension-contributed associations are resolved last-registered-wins (`languagesAssociations.ts`), which is not a contract and is fragile against other SQL extensions. It would also replace the richer built-in `source.sql` grammar and break language-scoped features from other SQL tooling.
+
+[`src/sqlAssociation.ts`](src/sqlAssociation.ts) shows a one-time notice pointing at `files.associations`, which is the right mechanism for users who want ggsql highlighting in `.sql` files because user-configured associations sit in the highest precedence tier and so win deterministically.
+
+**It does not write the setting.** Mapping `*.sql` rewrites how every `.sql` file in every workspace is treated, which is not an extension's call, and running SQL in the ggsql console does not need it. An earlier version did write it on a button press, and that turned out to need a reset command, an offer to un-write, and care over which config level to base the update on. None of that is needed now.
+
+Three constraints worth knowing before editing the notice:
+
+- **Notification text is not markdown.** It is parsed by `parseLinkedText`, which matches markdown links and nothing else, so code spans and emphasis render literally. Hrefs are limited to `https:`, `command:` and `file:`, and may contain no spaces or `)`. The setting name is therefore a `command:` link, and the mapping is spelled out in prose rather than backticked.
+- **Any button press dismisses the notification**, so every button has to be a complete answer. The documentation link lives on the `ggsql.enableSqlFiles` setting rather than being a button here.
+- **The notice fires on every `.sql` open, and only "Don't show again" persists.** An Info notification with buttons is *not* sticky (`notifications.ts` makes actions sticky only at Error severity), so it auto-hides after 10 seconds and extensions cannot opt out. A show-once notice is therefore trivially missed, which would defeat the point. A module-level `noticeVisible` guard stops that becoming a pile-up when many `.sql` files open at once. `ggsql: Reset .sql File Association Prompt` clears the persisted flag, the only route back from "Don't show again" short of editing the global storage database.
+
+The `ggsql.enableSqlFiles` description uses `markdownDescription` rather than `description`, which matters for two reasons: only the markdown path runs `fixSettingLinks`, and only it renders links at all. It uses both link forms available there:
+
+- `` `#files.associations#` `` renders as a link to that setting. The backticks (or single quotes) are required; a bare `#files.associations#` is left as literal text.
+- A plain markdown link to [`/doc/get_started/tooling/positron-vscode.qmd`](../doc/get_started/tooling/positron-vscode.qmd), whose `## Using ggsql with .sql files` heading carries an explicit `{#sql-files}` anchor so the URL survives a rewording. Keep the anchor if you edit that heading.
+
 ## Positron integration
 
 The extension declares `contributes.languageRuntimes` for `ggsql` (see `package.json`) and depends on `@posit-dev/positron`. When activated under Positron, `manager.ts`:

--- a/ggsql-vscode/CLAUDE.md
+++ b/ggsql-vscode/CLAUDE.md
@@ -13,7 +13,7 @@ ggsql-vscode/
 ├── esbuild.js                Bundler config (builds out/extension.js)
 ├── eslint.config.mjs
 ├── language-configuration.json   Bracket pairs, comment markers
-├── logo.png, icon.png
+├── logo.png                  Marketplace icon
 ├── src/
 │   ├── extension.ts          activate(): registers commands, manager, code lenses
 │   ├── manager.ts            Kernel discovery + Positron language-runtime registration
@@ -27,6 +27,8 @@ ggsql-vscode/
 │   └── ggsql.tmLanguage.json TextMate grammar (used for tokenization in VS Code)
 ├── examples/                 Sample .ggsql files
 ├── resources/                Static assets bundled with the extension
+│   ├── ggsql-icon.svg        Full-colour logo; read by manager.ts for base64EncodedIconSvg
+│   └── ggsql-lang-icon.svg   contributes.languages[].icon; tuned for the 16px file-icon slot
 └── ggsql-0.1.0.vsix          Packaged extension (build artifact, may be stale)
 ```
 

--- a/ggsql-vscode/package.json
+++ b/ggsql-vscode/package.json
@@ -38,8 +38,8 @@
         ],
         "configuration": "./language-configuration.json",
         "icon": {
-          "light": "./icon.png",
-          "dark": "./icon.png"
+          "light": "./resources/ggsql-lang-icon.svg",
+          "dark": "./resources/ggsql-lang-icon.svg"
         }
       }
     ],

--- a/ggsql-vscode/package.json
+++ b/ggsql-vscode/package.json
@@ -87,6 +87,11 @@
         "category": "ggsql",
         "title": "New ggsql File",
         "shortTitle": "ggsql File"
+      },
+      {
+        "command": "ggsql.resetSqlAssociationPrompt",
+        "category": "ggsql",
+        "title": "Reset .sql File Association Prompt"
       }
     ],
     "keybindings": [
@@ -113,11 +118,11 @@
         {
           "command": "ggsql.sourceCurrentFile",
           "group": "navigation@0",
-          "when": "resourceLangId == ggsql && !isInDiffEditor"
+          "when": "(resourceLangId == ggsql || (resourceLangId == sql && config.ggsql.enableSqlFiles)) && !isInDiffEditor"
         },
         {
           "command": "workbench.action.positronConsole.executeCode",
-          "when": "resourceLangId == ggsql && !isInDiffEditor"
+          "when": "(resourceLangId == ggsql || (resourceLangId == sql && config.ggsql.enableSqlFiles)) && !isInDiffEditor"
         }
       ],
       "file/newFile": [
@@ -136,6 +141,11 @@
           "type": "string",
           "default": "",
           "description": "Path to the ggsql-jupyter executable. If empty, uses 'ggsql-jupyter' from PATH."
+        },
+        "ggsql.enableSqlFiles": {
+          "type": "boolean",
+          "default": true,
+          "markdownDescription": "Offer ggsql run buttons and code cells in plain `.sql` files. ggsql is a superset of SQL, so the ggsql console can execute them. Turn this off if you use `.sql` files with other database tooling.\n\nTo also give `.sql` files ggsql syntax highlighting, map them to the ggsql language with `#files.associations#`. See [Using ggsql with `.sql` files](https://ggsql.org/get_started/tooling/positron-vscode.html#sql-files) for details."
         }
       }
     }

--- a/ggsql-vscode/package.json
+++ b/ggsql-vscode/package.json
@@ -99,18 +99,18 @@
         "command": "ggsql.runCurrentAdvance",
         "key": "ctrl+enter",
         "mac": "cmd+enter",
-        "when": "editorTextFocus && editorLangId == ggsql && ggsql.hasCodeCells && !findInputFocussed && !replaceInputFocussed"
+        "when": "isPositron && editorTextFocus && editorLangId == ggsql && ggsql.hasCodeCells && !findInputFocussed && !replaceInputFocussed"
       },
       {
         "command": "ggsql.runCurrentAdvance",
         "key": "shift+enter",
-        "when": "editorTextFocus && editorLangId == ggsql && ggsql.hasCodeCells && !findInputFocussed && !replaceInputFocussed"
+        "when": "isPositron && editorTextFocus && editorLangId == ggsql && ggsql.hasCodeCells && !findInputFocussed && !replaceInputFocussed"
       },
       {
         "command": "ggsql.runQuery",
         "key": "ctrl+shift+enter",
         "mac": "cmd+shift+enter",
-        "when": "editorTextFocus && editorLangId == ggsql && ggsql.hasCodeCells && !findInputFocussed && !replaceInputFocussed"
+        "when": "isPositron && editorTextFocus && editorLangId == ggsql && ggsql.hasCodeCells && !findInputFocussed && !replaceInputFocussed"
       }
     ],
     "menus": {
@@ -118,11 +118,11 @@
         {
           "command": "ggsql.sourceCurrentFile",
           "group": "navigation@0",
-          "when": "(resourceLangId == ggsql || (resourceLangId == sql && config.ggsql.enableSqlFiles)) && !isInDiffEditor"
+          "when": "isPositron && (resourceLangId == ggsql || (resourceLangId == sql && config.ggsql.enableSqlFiles)) && !isInDiffEditor"
         },
         {
           "command": "workbench.action.positronConsole.executeCode",
-          "when": "(resourceLangId == ggsql || (resourceLangId == sql && config.ggsql.enableSqlFiles)) && !isInDiffEditor"
+          "when": "isPositron && (resourceLangId == ggsql || (resourceLangId == sql && config.ggsql.enableSqlFiles)) && !isInDiffEditor"
         }
       ],
       "file/newFile": [
@@ -130,6 +130,28 @@
           "command": "ggsql.createNewFile",
           "group": "ggsql",
           "when": "!virtualWorkspace"
+        }
+      ],
+      "commandPalette": [
+        {
+          "command": "ggsql.sourceCurrentFile",
+          "when": "isPositron"
+        },
+        {
+          "command": "ggsql.runQuery",
+          "when": "isPositron"
+        },
+        {
+          "command": "ggsql.runCellsAbove",
+          "when": "isPositron"
+        },
+        {
+          "command": "ggsql.runNextCell",
+          "when": "isPositron"
+        },
+        {
+          "command": "ggsql.runCurrentAdvance",
+          "when": "isPositron"
         }
       ]
     },

--- a/ggsql-vscode/package.json
+++ b/ggsql-vscode/package.json
@@ -32,9 +32,9 @@
       {
         "id": "ggsql",
         "extensions": [
+          ".gsql",
           ".ggsql",
-          ".ggsql.sql",
-          ".gsql"
+          ".ggsql.sql"
         ],
         "configuration": "./language-configuration.json",
         "icon": {
@@ -81,6 +81,12 @@
         "command": "ggsql.runCurrentAdvance",
         "category": "ggsql",
         "title": "Run Query and Advance"
+      },
+      {
+        "command": "ggsql.createNewFile",
+        "category": "ggsql",
+        "title": "New ggsql File",
+        "shortTitle": "ggsql File"
       }
     ],
     "keybindings": [
@@ -112,6 +118,13 @@
         {
           "command": "workbench.action.positronConsole.executeCode",
           "when": "resourceLangId == ggsql && !isInDiffEditor"
+        }
+      ],
+      "file/newFile": [
+        {
+          "command": "ggsql.createNewFile",
+          "group": "ggsql",
+          "when": "!virtualWorkspace"
         }
       ]
     },

--- a/ggsql-vscode/resources/ggsql-lang-icon.svg
+++ b/ggsql-vscode/resources/ggsql-lang-icon.svg
@@ -1,0 +1,17 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="-132.35 -39.99 640.70 640.70">
+  <!-- ggsql language icon for the 16px file-icon slot. Single flat fill with
+       transparent seams, following the file-icon-theme idiom: the background
+       shows through the cuts, so one geometry serves light and dark themes.
+       Ink spans 87.5% of the square viewBox, landing at 14px in a 16px slot.
+
+       Seams are 0.8px there, a 1:3.6 gap-to-band ratio. Because they run at the
+       logo's 29 degree tilt they never align to a pixel row, so they clear only
+       about 64% of the way to the background rather than fully. Narrowing them
+       further mutes them into teal lines instead of gaps.
+
+       The viewBox is centred on the shape's area centroid, not its bounding box.
+       The thick body sits up-right while the point trails down-left, putting the
+       centroid 0.55px left of the bbox centre, which made the icon read as shifted
+       left. Centring the centroid offsets the ink right by that much. -->
+  <path fill="#0A9396" fill-rule="evenodd" d="M417.27,160.98L419.70,151.30L417.07,138.29L401.89,114.05L375.13,87.41L338.79,60.25L299.63,37.14L259.84,18.66L219.44,5.30L185.68,0.05L162.67,3.02L150.15,13.11L108.70,87.88L375.63,235.84ZM267.15,430.88L310.72,352.55L43.96,204.68L2.51,279.45L0.04,291.10L2.25,299.50L252.92,438.45ZM19.69,557.55L23.34,560.66L219.21,456.40L5.71,338.05ZM360.06,263.84L93.17,115.90L59.49,176.66L326.29,324.55Z"/>
+</svg>

--- a/ggsql-vscode/src/codelens.ts
+++ b/ggsql-vscode/src/codelens.ts
@@ -1,8 +1,31 @@
 import * as vscode from 'vscode';
 import { parseCells, type Cell } from './cellParser';
+import { isGgsqlDocument } from './languages';
 
 export class GgsqlCodeLensProvider implements vscode.CodeLensProvider {
+	private readonly changed = new vscode.EventEmitter<void>();
+
+	/** Fired when `ggsql.enableSqlFiles` changes, so `.sql` lenses appear or clear. */
+	readonly onDidChangeCodeLenses = this.changed.event;
+
+	constructor(disposables: vscode.Disposable[]) {
+		disposables.push(
+			this.changed,
+			vscode.workspace.onDidChangeConfiguration(event => {
+				if (event.affectsConfiguration('ggsql.enableSqlFiles')) {
+					this.changed.fire();
+				}
+			}),
+		);
+	}
+
 	provideCodeLenses(document: vscode.TextDocument): vscode.CodeLens[] {
+		// Registered for `sql` as well as `ggsql`, so gate here rather than at
+		// registration time; that way the setting takes effect immediately.
+		if (!isGgsqlDocument(document)) {
+			return [];
+		}
+
 		const cells = parseCells(document);
 		const lenses: vscode.CodeLens[] = [];
 
@@ -54,7 +77,7 @@ export function registerCellCommands(
 	context.subscriptions.push(
 		vscode.commands.registerCommand('ggsql.runQuery', (line?: number) => {
 			const editor = vscode.window.activeTextEditor;
-			if (!editor || editor.document.languageId !== 'ggsql') { return; }
+			if (!editor || !isGgsqlDocument(editor.document)) { return; }
 			const cells = parseCells(editor.document);
 			const cell = line !== undefined
 				? findCellAtLine(cells, line)
@@ -66,7 +89,7 @@ export function registerCellCommands(
 
 		vscode.commands.registerCommand('ggsql.runCurrentAdvance', (line?: number) => {
 			const editor = vscode.window.activeTextEditor;
-			if (!editor || editor.document.languageId !== 'ggsql') { return; }
+			if (!editor || !isGgsqlDocument(editor.document)) { return; }
 			const cells = parseCells(editor.document);
 			const targetLine = line ?? editor.selection.active.line;
 			const cell = findCellAtLine(cells, targetLine);
@@ -84,7 +107,7 @@ export function registerCellCommands(
 
 		vscode.commands.registerCommand('ggsql.runCellsAbove', (line?: number) => {
 			const editor = vscode.window.activeTextEditor;
-			if (!editor || editor.document.languageId !== 'ggsql') { return; }
+			if (!editor || !isGgsqlDocument(editor.document)) { return; }
 			const cells = parseCells(editor.document);
 			const cursor = new vscode.Position(line ?? editor.selection.active.line, 0);
 			cells
@@ -98,7 +121,7 @@ export function registerCellCommands(
 
 		vscode.commands.registerCommand('ggsql.runNextCell', (line?: number) => {
 			const editor = vscode.window.activeTextEditor;
-			if (!editor || editor.document.languageId !== 'ggsql') { return; }
+			if (!editor || !isGgsqlDocument(editor.document)) { return; }
 			const cells = parseCells(editor.document);
 			const targetLine = line ?? editor.selection.active.line;
 			const next = findNextCell(cells, targetLine);

--- a/ggsql-vscode/src/context.ts
+++ b/ggsql-vscode/src/context.ts
@@ -1,9 +1,10 @@
 import * as vscode from 'vscode';
 import { parseCells } from './cellParser';
+import { isGgsqlDocument } from './languages';
 
 function setHasCodeCells(editor: vscode.TextEditor | undefined): void {
 	let value = false;
-	if (editor && editor.document.languageId === 'ggsql') {
+	if (editor && isGgsqlDocument(editor.document)) {
 		value = parseCells(editor.document).length > 0;
 	}
 	vscode.commands.executeCommand('setContext', 'ggsql.hasCodeCells', value);

--- a/ggsql-vscode/src/decorations.ts
+++ b/ggsql-vscode/src/decorations.ts
@@ -1,5 +1,6 @@
 import * as vscode from 'vscode';
 import { parseCells } from './cellParser';
+import { isGgsqlDocument } from './languages';
 
 const activeCellBackground = new vscode.ThemeColor('notebook.selectedCellBackground');
 
@@ -13,7 +14,7 @@ export function activateDecorations(disposables: vscode.Disposable[]): void {
 	let activeEditor = vscode.window.activeTextEditor;
 
 	function updateDecorations() {
-		if (!activeEditor || activeEditor.document.languageId !== 'ggsql') {
+		if (!activeEditor || !isGgsqlDocument(activeEditor.document)) {
 			return;
 		}
 

--- a/ggsql-vscode/src/extension.ts
+++ b/ggsql-vscode/src/extension.ts
@@ -29,6 +29,14 @@ export function log(message: string): void {
 export function activate(context: vscode.ExtensionContext): void {
     log('ggsql extension activating...');
 
+    // Register "New ggsql File" for the New File dialog
+    context.subscriptions.push(
+        vscode.commands.registerCommand('ggsql.createNewFile', async () => {
+            const document = await vscode.workspace.openTextDocument({ language: 'ggsql' });
+            await vscode.window.showTextDocument(document);
+        })
+    );
+
     // Try to acquire the Positron API
     const positronApi = tryAcquirePositronApi();
 

--- a/ggsql-vscode/src/extension.ts
+++ b/ggsql-vscode/src/extension.ts
@@ -13,6 +13,8 @@ import { GgsqlCodeLensProvider, registerCellCommands } from './codelens';
 import { activateDecorations } from './decorations';
 import { activateContextKeys } from './context';
 import { parseCells } from './cellParser';
+import { CELL_LANGUAGE_IDS, isGgsqlDocument } from './languages';
+import { activateSqlAssociationPrompt } from './sqlAssociation';
 
 // Output channel for logging
 const outputChannel = vscode.window.createOutputChannel('ggsql');
@@ -36,6 +38,9 @@ export function activate(context: vscode.ExtensionContext): void {
             await vscode.window.showTextDocument(document);
         })
     );
+
+    // Offer to associate .sql files with ggsql
+    activateSqlAssociationPrompt(context);
 
     // Try to acquire the Positron API
     const positronApi = tryAcquirePositronApi();
@@ -69,7 +74,7 @@ export function activate(context: vscode.ExtensionContext): void {
     context.subscriptions.push(
         vscode.commands.registerCommand('ggsql.sourceCurrentFile', async () => {
             const editor = vscode.window.activeTextEditor;
-            if (!editor || editor.document.languageId !== 'ggsql') {
+            if (!editor || !isGgsqlDocument(editor.document)) {
                 return;
             }
             const cells = parseCells(editor.document);
@@ -91,7 +96,10 @@ export function activate(context: vscode.ExtensionContext): void {
 
     // Register code lens provider and cell commands
     context.subscriptions.push(
-        vscode.languages.registerCodeLensProvider('ggsql', new GgsqlCodeLensProvider()),
+        vscode.languages.registerCodeLensProvider(
+            CELL_LANGUAGE_IDS,
+            new GgsqlCodeLensProvider(context.subscriptions),
+        ),
     );
     registerCellCommands(context, (code) => {
         positronApi.runtime.executeCode('ggsql', code, false, true);

--- a/ggsql-vscode/src/languages.ts
+++ b/ggsql-vscode/src/languages.ts
@@ -1,0 +1,44 @@
+/*
+ * Which documents ggsql attaches to.
+ *
+ * ggsql is a superset of SQL, so the kernel can execute a plain `.sql` file.
+ * The extension therefore offers its run affordances on documents tokenized as
+ * `sql` as well as `ggsql`, without claiming the `.sql` file association. That
+ * keeps the richer built-in SQL grammar in place for plain SQL, and leaves
+ * language-scoped features from other SQL extensions working.
+ *
+ * Users who want the full ggsql treatment for `.sql` files (ggsql syntax
+ * highlighting, the ggsql file icon) set `files.associations` instead, which
+ * outranks every extension-contributed association. `sqlAssociation.ts` offers
+ * to do that for them.
+ */
+
+import * as vscode from 'vscode';
+
+export const GGSQL_LANGUAGE_ID = 'ggsql';
+export const SQL_LANGUAGE_ID = 'sql';
+
+/**
+ * Language ids the CodeLens provider registers against. Both are registered
+ * unconditionally; `isGgsqlDocument` gates `sql` at request time so that
+ * toggling the setting takes effect without re-registering providers.
+ */
+export const CELL_LANGUAGE_IDS = [GGSQL_LANGUAGE_ID, SQL_LANGUAGE_ID];
+
+/** Whether ggsql offers its run affordances in plain `.sql` files. */
+export function sqlFilesEnabled(): boolean {
+	return vscode.workspace
+		.getConfiguration('ggsql')
+		.get<boolean>('enableSqlFiles', true);
+}
+
+/** True when ggsql is willing to execute the contents of `document`. */
+export function isGgsqlDocument(document: vscode.TextDocument | undefined): boolean {
+	if (!document) {
+		return false;
+	}
+	if (document.languageId === GGSQL_LANGUAGE_ID) {
+		return true;
+	}
+	return document.languageId === SQL_LANGUAGE_ID && sqlFilesEnabled();
+}

--- a/ggsql-vscode/src/sqlAssociation.ts
+++ b/ggsql-vscode/src/sqlAssociation.ts
@@ -1,0 +1,163 @@
+/*
+ * Points users at `files.associations` when they open a plain `.sql` file.
+ *
+ * Running SQL through the ggsql kernel already works without any association
+ * (see `languages.ts`); mapping the files additionally gives them ggsql syntax
+ * highlighting and the ggsql file icon. That is a preference, not a
+ * prerequisite, so the extension only surfaces the option and lets the user
+ * make the change. It deliberately does not write `files.associations` itself:
+ * mapping `*.sql` globally rewrites how every `.sql` file in every workspace is
+ * treated, which is not a decision an extension should take on someone's behalf.
+ *
+ * `files.associations` is the right mechanism for users who do want it, because
+ * user-configured associations outrank every extension-contributed one and so
+ * win deterministically even with other SQL extensions installed.
+ *
+ * The notice appears on each `.sql` file opened until dismissed for good, and
+ * never when `*.sql` is already mapped.
+ */
+
+import * as vscode from 'vscode';
+import { SQL_LANGUAGE_ID, sqlFilesEnabled } from './languages';
+import { log } from './extension';
+
+/** Set once the user has actively dismissed the notice for good. */
+const PROMPTED_KEY = 'ggsql.sqlAssociationPrompted';
+
+const SQL_GLOB = '*.sql';
+
+const SETTINGS_QUERY = 'files.associations';
+
+/**
+ * True while a notice is on screen awaiting an answer.
+ *
+ * The notice is shown every time a `.sql` file is opened, because an Info
+ * notification with buttons is not sticky and auto-hides after 10 seconds
+ * (`notificationsToasts.ts`), and extensions cannot opt out of that: a
+ * show-once notice is trivially missed. Letting it age out is therefore not
+ * treated as an answer, only "Don't show again" is.
+ *
+ * This guard keeps that from becoming a pile-up. Opening a folder full of
+ * `.sql` files, or another extension opening them in the background, would
+ * otherwise queue one notice per file; instead the first is shown and the rest
+ * are skipped while it is still pending.
+ */
+let noticeVisible = false;
+
+/**
+ * True when `*.sql` is already mapped at any level.
+ *
+ * Reads the *effective* value on purpose: if a default, a workspace or the user
+ * maps `*.sql` to anything, there is nothing to tell them about.
+ */
+function hasSqlAssociation(): boolean {
+	const associations = vscode.workspace
+		.getConfiguration('files')
+		.get<Record<string, string>>('associations', {});
+	return SQL_GLOB in associations;
+}
+
+/*
+ * Notification text is parsed by `parseLinkedText`, which understands markdown
+ * links and nothing else: no code spans, no emphasis. Backticks would render
+ * literally, so the mapping is spelled out in prose and the setting name is a
+ * command link. Only https, command and file hrefs are permitted, and the href
+ * may contain no spaces or `)`.
+ *
+ * `workbench.action.openSettings` takes its query as a plain string argument,
+ * and the opener JSON-parses the URI query then wraps a non-array in an array,
+ * so an encoded bare string is enough.
+ */
+const SETTINGS_LINK =
+	`[Files: Associations](command:workbench.action.openSettings?%22files.associations%22)`;
+
+const MESSAGE =
+	'You can run this .sql file in the ggsql console. For ggsql syntax highlighting in '
+	+ `.sql files as well, map "${SQL_GLOB}" to "ggsql" in ${SETTINGS_LINK}.`;
+
+async function showNotice(context: vscode.ExtensionContext): Promise<void> {
+	noticeVisible = true;
+	const showSetting = 'Show Setting';
+	const dontShow = 'Don\'t show again';
+	let choice: string | undefined;
+	try {
+		choice = await vscode.window.showInformationMessage(MESSAGE, showSetting, dontShow);
+	} finally {
+		noticeVisible = false;
+	}
+
+	if (choice === showSetting) {
+		await vscode.commands.executeCommand('workbench.action.openSettings', SETTINGS_QUERY);
+	}
+	// Only an explicit "don't show again" is persisted. Anything else, including
+	// the toast ageing out unseen, leaves the notice free to appear again.
+	if (choice === dontShow) {
+		await context.globalState.update(PROMPTED_KEY, true);
+	}
+}
+
+/**
+ * Clears the persisted dismissal so the notice can appear again.
+ *
+ * Only reachable state to undo is "Don't show again", which otherwise has no
+ * route back short of editing the global storage database.
+ */
+async function resetNotice(context: vscode.ExtensionContext): Promise<void> {
+	await context.globalState.update(PROMPTED_KEY, undefined);
+	log('Reset the .sql association notice');
+
+	if (hasSqlAssociation()) {
+		// An existing mapping makes `.sql` files open as `ggsql`, so the notice
+		// still will not fire. Say so rather than appearing to have done nothing.
+		void vscode.window.showInformationMessage(
+			`Notice reset, but "${SQL_GLOB}" is still mapped in ${SETTINGS_QUERY}, so .sql `
+			+ 'files open as ggsql and the notice stays hidden. Remove that mapping to see it.',
+		);
+		return;
+	}
+
+	void vscode.window.showInformationMessage(
+		'ggsql will mention the .sql association again next time you open a .sql file.',
+	);
+}
+
+/**
+ * Mentions the association whenever a plain `.sql` document is opened.
+ *
+ * Registered regardless of whether Positron is present: the association affects
+ * syntax highlighting, which is useful even where the kernel cannot run.
+ */
+export function activateSqlAssociationPrompt(context: vscode.ExtensionContext): void {
+	context.subscriptions.push(
+		vscode.commands.registerCommand(
+			'ggsql.resetSqlAssociationPrompt',
+			() => resetNotice(context),
+		),
+	);
+
+	const maybeNotify = (document: vscode.TextDocument | undefined): void => {
+		if (!document || document.languageId !== SQL_LANGUAGE_ID) {
+			return;
+		}
+		// Only real files on disk; skip untitled buffers, diffs and output panes.
+		if (document.uri.scheme !== 'file') {
+			return;
+		}
+		if (noticeVisible || context.globalState.get<boolean>(PROMPTED_KEY)) {
+			return;
+		}
+		if (hasSqlAssociation()) {
+			return;
+		}
+		if (!sqlFilesEnabled()) {
+			return;
+		}
+		void showNotice(context);
+	};
+
+	maybeNotify(vscode.window.activeTextEditor?.document);
+
+	context.subscriptions.push(
+		vscode.workspace.onDidOpenTextDocument(maybeNotify),
+	);
+}


### PR DESCRIPTION
- Closes posit-dev/positron#14953
- Closes posit-dev/positron#14955
- Closes posit-dev/positron#14971

This PR provides three extension improvements, all of which are focused on improving discoverability. Two of the three issues above describe the current situation slightly inaccurately, so this PR does not implement them literally.

This PR also fixes a pre-existing bug where plain VS Code offered run actions that had no handler. That is the last section down there at the bottom.

## posit-dev/positron#14953: language icon missing

It turns out that `contributes.languages[].icon` pointed at `./icon.png`, which does not exist and never has; the only images shipped are `logo.png` and `resources/ggsql-icon.svg`.

Nothing validates that path, so `languageService` handed back a URI to a missing file and the icon theme emitted a rule with `content: '\2001'` (an em quad, used so image icons do not collapse to zero height) plus a `background-image` that 404s. The result is correctly sized blank space. The broken contribution was worse than no contribution at all. Without it, the item would have fallen through to Seti's generic file glyph, but the language-icon rule is more specific and won.

This PR adds a new `resources/ggsql-lang-icon.svg` that is a single flat `#0A9396` fill with transparent seams, following the file-icon-theme idiom where the background shows through the cuts rather than a second colour being painted. One geometry therefore serves light and dark themes, and `icon.light` and `icon.dark` point at the same file. `#0A9396` is 3.73:1 on white and 4.42:1 on `#1f1f1f`, so it clears the 3:1 floor for non-text graphics on both; the dark and light teals from the logo each fail on one background, which is why a single file works and a colour pair would not.

The geometry is derived from the logo rather than redrawn: a boolean union of its own path data, preserving the 29 degree tilt, with three seams subtracted on the logo's own band boundaries. Ink spans 87.5% of a square viewBox, landing at 14px in the 16px slot to match the `positron-r` reference icon's weight. The viewBox is centred on the shape's area centroid rather than its bounding box, because the thick body sits up-right while the point trails down-left, which made the icon read as shifted left.

This problem was actually broader than the issue reports. Both surfaces named in the issue, the interpreter selector and the console pane, resolve icons through `getSessionIconClasses` and so are both fixed. The same broken rule was also suppressing the icon for `.gsql` files in the Explorer, editor tabs and breadcrumbs, which the issue does not mention. `resources/ggsql-icon.svg` is untouched, since `manager.ts` still reads it for `base64EncodedIconSvg`.

Here are some screenshots of how this looks now, in various parts of the IDE:

<img width="634" height="302" alt="Screenshot 2026-07-29 at 7 33 44 PM" src="https://github.com/user-attachments/assets/088d9608-0d85-4e32-a480-ea08f85d7162" />

<img width="888" height="424" alt="Screenshot 2026-07-29 at 7 34 36 PM" src="https://github.com/user-attachments/assets/23c36bad-fce7-42e3-8c45-54db3eebe6cb" />

<img width="232" height="200" alt="Screenshot 2026-07-29 at 7 34 45 PM" src="https://github.com/user-attachments/assets/4a95d58e-bd34-4b6d-b920-62c096ce166b" />

It does _not_ change the parts of the IDE where we use the "real" logo:

<img width="612" height="344" alt="Screenshot 2026-07-29 at 6 50 41 PM" src="https://github.com/user-attachments/assets/0debcafb-420e-4885-8a0d-b843c52f10a4" />


## posit-dev/positron#14955: ggsql file type in New File

Adds a `ggsql.createNewFile` command contributed to the `file/newFile` menu, so _New File..._ offers "ggsql File". It opens an untitled document with the `ggsql` language, matching how `positron-r` and `positron-python` and many other extensions implement the same contribution.

FYI the issue and ggsql's own docs use `.gsql` as the main extension, and that needed a manifest change to actually work. `contributes.languages[].extensions` listed `.ggsql` first, and `textFileService.suggestFilename` uses `extensions.at(0)`, so saving an untitled ggsql document suggested `Untitled-1.ggsql`. The array is reordered to put `.gsql` first, which also matches the docs, which use `.gsql` everywhere a real file extension appears, and never `.ggsql`. All three extensions stay registered, so existing files keep working.

Unlike `positron-r` and `positron-python`, which use `group: "file"`, this uses its own `ggsql` group so the entry appears under its own heading like Quarto rather than mixed in with the built-in file types, reflecting that ggsql is not built into Positron:

<img width="628" height="282" alt="Screenshot 2026-07-29 at 8 35 59 PM" src="https://github.com/user-attachments/assets/070011ea-dae9-4be0-8ab8-45e24ce4a08a" />

## posit-dev/positron#14971: using `.sql` files with ggsql

FYI the issue's premise conflates two separate things, and the more useful fix is not the one it proposes. It states that running code in a `.sql` file with a ggsql kernel requires setting `files.associations`. Execution never actually required that. `executeCode('ggsql', ...)` names the runtime explicitly, so the document's language id is irrelevant to running the code; the setting was only needed because the extension gated its own run affordances on `resourceLangId == ggsql`.

So rather than making the association easier to reach, this removes the need for it. The "Source Current File" button, the code cells and the CodeLens now attach to `sql` documents as well as `ggsql` ones. Running SQL in a ggsql console works out of the box, with no settings change at all.

That leaves `files.associations` doing only what it really should, opting in to ggsql *syntax highlighting* for `.sql` files.

I don't think the extension should write that setting, so ideas 2 and 3 in the issue are deliberately not implemented as described. Mapping `*.sql` rewrites how every `.sql` file in every workspace is treated. It replaces the built-in `source.sql` grammar, which might arguably be the better grammar for plain SQL, and it breaks language-scoped features from other SQL tooling such as mssql, SQLTools, dbt, etc. I did try a version of this that actually changes the setting on a button press, and that turned out to require a reset command, an offer to un-write, and care about which config level to base the update on. I no longer think we should do this.

Instead, opening a `.sql` file shows a notice pointing at the setting, with a **Show Setting** button that opens it directly and a **Don't show again** button. The notice fires on each open rather than once, because an Info notification in an extension with buttons is not sticky and auto-hides after 10 seconds with no way for an extension to opt out, so a show-once notice is pretty easy to miss. A guard prevents a pile-up when many `.sql` files open at once, and only "Don't show again" is persisted, so letting the toast age out unseen is not treated as an answer:

<img width="475" height="158" alt="Screenshot 2026-07-29 at 9 18 38 PM" src="https://github.com/user-attachments/assets/6184f9bd-91fd-4a1a-b6c5-a6bca2646f3a" />

I did consider just claiming `.sql` in `contributes.languages` but I decided that's a bad idea. Extension-contributed associations resolve last-registered-wins, which is not a contract and is fragile against other SQL extensions, whereas user-configured associations sit in the highest precedence tier and win deterministically.

New `ggsql.enableSqlFiles` setting (default `true`) can turn the `.sql` behaviour off for anyone who uses `.sql` files with other database tooling.

## Also fixed: dead run actions in plain VS Code

I noticed I was making this problem worse, although it predates my work here. On `main` the `editor/title/run` buttons were already contributed with `when: resourceLangId == ggsql && !isInDiffEditor`, with no Positron gate. Every command that executes code is registered *after* `activate()` returns early when the Positron API is absent, so plain VS Code has always shown a run button on `.gsql` files with no handler behind it. 

Everything execution-related now gates on Positron's built-in `isPositron` context key, per the [extension development docs](https://positron.posit.co/extension-development.html#option-1-context-keys): the two `editor/title/run` buttons, the three keybindings, and the five run commands, which are hidden from the Command Palette through a new `commandPalette` menu entry. `ggsql.createNewFile` and `ggsql.resetSqlAssociationPrompt` are deliberately left ungated, since they work without Positron.

`ggsql-vscode/CLAUDE.md` claimed "Outside Positron, the same commands fall back to writing query output to the active terminal." No such fallback exists anywhere in `src/`, which is plausibly why this went unnoticed. That line is replaced with a description of the actual behaviour and of which side of the early return new commands belong on.

## A few details

- All seven inline `languageId === 'ggsql'` checks now route through `isGgsqlDocument()` in the new `src/languages.ts`, rather than each growing its own `|| 'sql'` branch.
- The CodeLens provider registers for both language ids and gates at request time, firing `onDidChangeCodeLenses` when the setting changes, so toggling it takes effect without re-registering.
- `ggsql-vscode/CLAUDE.md` listed a non-existent `icon.png` in its layout tree, which is presumably how the broken manifest path arose. Corrected.
- Docs gain a "Using ggsql with `.sql` files" section, with an explicit `{#sql-files}` anchor and then the setting description links to it.

## Verification

`tsc --noEmit`, `eslint`, and a production `esbuild` run are clean. The icon was rendered through headless Chromium at true slot geometry (16px `background-size` in a 16x22 box) on `#ffffff`, `#1f1f1f` and `#252526`, alongside the real Seti python, R and SQL glyphs and the `positron-r` reference icon, to confirm legibility and matching weight.

