### PR TITLE
Fix blank plots in Positron notebooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,12 @@
 - In plain VS Code, the extension no longer offers run buttons, keybindings or
   Command Palette entries for commands that need the Positron runtime and so
   had no handler there.
+- Plots in Positron notebooks no longer come out blank when the cell output is
+  rendered before Positron has laid the slot out, which happened on the first
+  execution after a kernel started and when reopening a saved notebook. The
+  plot sizes itself from its container, so a zero-width first measurement drew
+  it at zero size with nothing left to correct it. It now recovers once the
+  container has a real width.
 
 ## 0.4.1 - 2026-06-22
 

--- a/ggsql-jupyter/src/display.rs
+++ b/ggsql-jupyter/src/display.rs
@@ -14,9 +14,9 @@ use serde_json::{json, Value};
 /// incoming execute_request:
 ///
 /// - **Positron notebook** (`ggsql-notebook-…`): inline code-chunk output
-///   in an editor view. Rendered into a plain 400px container with no
-///   layout-mutating observers, because Positron animates the slot during
-///   its reveal transition.
+///   in an editor view. Rendered into a plain 400px container that watches
+///   layout only when the first measurement collapsed, because Positron
+///   animates the slot during its reveal transition.
 /// - **Positron console** (`ggsql-…`): output lands in the Plots pane. The
 ///   container upgrades to `100vh` inside `.positron-output-container`, so
 ///   Vega-Lite's own container observer tracks pane resizes.
@@ -135,11 +135,21 @@ pub fn vegalite_html(spec: &str, hints: &RenderHints) -> String {
     }
 }
 
-/// Positron template: plain 400px container with no self-installed layout
-/// observers. Console sessions additionally upgrade the container to `100vh`
-/// when it lives inside `.positron-output-container`, letting Vega-Lite's
-/// own container observer keep the Plots pane responsive. Notebook sessions
-/// skip that override and keep a stable 400px box.
+/// Positron template: plain 400px container. Console sessions additionally
+/// upgrade the container to `100vh` when it lives inside
+/// `.positron-output-container`, letting Vega-Lite's own container observer
+/// keep the Plots pane responsive. Notebook sessions skip that override and
+/// keep a stable 400px box.
+///
+/// Container sizing compiles to `width`/`height` signals that re-read
+/// `containerSize()` only on `window:resize`, and `isFinite(0)` holds, so a plot
+/// measured before Positron lays the slot out stays zero-sized with no error.
+/// `recoverIfCollapsed` fixes that, and two details are load-bearing: it gates
+/// on `view.width()` rather than the container's `clientWidth`, which can
+/// already be non-zero while the view is not, and it dispatches `resize` rather
+/// than calling `view.resize()`, which re-lays out from the same zero. It
+/// watches only a collapsed plot and stops once the view has a size, so it
+/// cannot re-lay out on every frame of Positron's reveal transition.
 fn positron_vegalite_html(spec_json: &str, vis_id: &str, is_notebook: bool) -> String {
     let pane_override_js = if is_notebook {
         ""
@@ -157,6 +167,21 @@ fn positron_vegalite_html(spec_json: &str, vis_id: &str, is_notebook: bool) -> S
 var spec = {spec_json};
 var visId = '{vis_id}';
 var options = {{"actions": true, "renderer": "svg"}};
+function recoverIfCollapsed(result) {{
+var el = document.getElementById(visId);
+if (!el || !result || !result.view) {{ return; }}
+if (typeof ResizeObserver === 'undefined') {{ return; }}
+if (result.view.width() > 0 && result.view.height() > 0) {{ return; }}
+var lastWidth = -1;
+var ro = new ResizeObserver(function() {{
+if (result.view.width() > 0 && result.view.height() > 0) {{ ro.disconnect(); return; }}
+var w = el.clientWidth;
+if (w === 0 || w === lastWidth) {{ return; }}
+lastWidth = w;
+window.dispatchEvent(new Event('resize'));
+}});
+ro.observe(el);
+}}
 {pane_override_js}
 if (typeof window.requirejs !== 'undefined') {{
 window.requirejs.config({{
@@ -174,7 +199,7 @@ else window.addEventListener("load", function() {{ fn(); }});
 docReady(function() {{
 window.requirejs(["dom-ready", "vega", "vega-embed"], function(domReady, vega, vegaEmbed) {{
 domReady(function () {{
-vegaEmbed('#' + visId, spec, options).catch(console.error);
+vegaEmbed('#' + visId, spec, options).then(recoverIfCollapsed).catch(console.error);
 }});
 }});
 }});
@@ -194,6 +219,7 @@ loadScript('https://cdn.jsdelivr.net/npm/vega-lite@6.4.1'),
 loadScript('https://cdn.jsdelivr.net/npm/vega-embed@7')
 ])
 .then(function() {{ return vegaEmbed('#' + visId, spec, options); }})
+.then(recoverIfCollapsed)
 .catch(function(err) {{
 console.error('Failed to load Vega libraries:', err);
 }});
@@ -443,19 +469,79 @@ mod tests {
 
     #[test]
     fn test_positron_html_has_no_observer_feedback_loop() {
-        // Positron templates must not install a `ResizeObserver` or a
-        // `scaleToFit` transform: Positron animates the output slot during
-        // reveal, and either one would re-lay out on every animation frame.
+        // Positron animates the output slot during reveal, so the templates
+        // must not watch layout once the plot has drawn. The only observer is
+        // the collapsed-render recovery, and it disconnects as soon as the
+        // view has a size.
         for hints in [positron_console(), positron_notebook()] {
             let html = vegalite_html(r#"{"mark": "point"}"#, &hints);
             assert!(
-                !html.contains("new ResizeObserver"),
-                "Positron HTML must not install a ResizeObserver (hints={:?})",
+                !html.contains("scaleToFit"),
+                "Positron HTML must not include scaleToFit (hints={:?})",
+                hints
+            );
+            assert_eq!(
+                html.matches("new ResizeObserver").count(),
+                1,
+                "the collapsed-render recovery is the only observer (hints={:?})",
                 hints
             );
             assert!(
-                !html.contains("scaleToFit"),
-                "Positron HTML must not include scaleToFit (hints={:?})",
+                html.contains("ro.disconnect();"),
+                "the observer must disconnect once the view has a size (hints={:?})",
+                hints
+            );
+        }
+    }
+
+    #[test]
+    fn test_positron_recovery_gates_on_rendered_view_size() {
+        // The container can report a width while the view is still laid out at
+        // the zero it captured earlier, so gating on `clientWidth` here would
+        // skip a plot that did collapse.
+        for hints in [positron_console(), positron_notebook()] {
+            let html = vegalite_html(r#"{"mark": "point"}"#, &hints);
+            assert!(
+                html.contains(
+                    "if (result.view.width() > 0 && result.view.height() > 0) { return; }"
+                ),
+                "recovery must gate on the size the view rendered at (hints={:?})",
+                hints
+            );
+        }
+    }
+
+    #[test]
+    fn test_positron_recovery_dispatches_a_resize_event() {
+        // Container sizing compiles to width/height signals that re-read
+        // `containerSize()` only on `window:resize`. `view.resize()` re-lays out
+        // from the current signal value, which is still zero, so it cannot
+        // recover a collapsed plot.
+        for hints in [positron_console(), positron_notebook()] {
+            let html = vegalite_html(r#"{"mark": "point"}"#, &hints);
+            assert!(
+                html.contains("window.dispatchEvent(new Event('resize'));"),
+                "recovery must dispatch the event the signal listens for (hints={:?})",
+                hints
+            );
+            assert!(
+                !html.contains("view.resize()"),
+                "view.resize() does not re-read containerSize (hints={:?})",
+                hints
+            );
+        }
+    }
+
+    #[test]
+    fn test_positron_html_recovers_on_both_load_paths() {
+        // vega-embed is reached either through requirejs or through direct
+        // script loading; a plot that collapsed must recover either way.
+        for hints in [positron_console(), positron_notebook()] {
+            let html = vegalite_html(r#"{"mark": "point"}"#, &hints);
+            assert_eq!(
+                html.matches("recoverIfCollapsed").count(),
+                3,
+                "recovery must be defined once and wired into both load paths (hints={:?})",
                 hints
             );
         }


### PR DESCRIPTION
Fixes posit-dev/positron#13106

## What was actually broken

Plots came out blank in Positron notebooks on the first execution after a kernel started, and again when reopening a saved notebook. Running the cell a second time rendered it fine. There was no error anywhere: no console output, no failed request, just empty space where the plot should be.

What was happening was that Vega-Lite compiles `width: "container"` into `width` and `height` signals that re-read `containerSize()` only on a `window:resize` event. Positron sometimes renders cell output into a slot before it has laid that slot out, so the first measurement comes back zero at times. Since `isFinite(0)` is true, the zero sticks rather than falling back to a default, and the plot draws at zero size with nothing left to re-measure it.

## The fix

The Positron templates now call `recoverIfCollapsed` once vega-embed resolves. Two details are load-bearing, and both are easy to "simplify" into something that does not work:

- It gates on `view.width()`, the size the view actually rendered at, not the container's `clientWidth`. The container can already report a width while the view is still sitting at the zero it captured earlier.
- It recovers by dispatching `resize`, the event the compiled signal listens for. `view.resize()` does not help, because it re-lays out from the same zero signal.

The observer only exists for a plot that collapsed, and it disconnects as soon as the view has a size, so it does not re-lay out on every frame of Positron's reveal animation:

<img width="1486" height="1008" alt="Screenshot 2026-08-07 at 3 41 11 PM" src="https://github.com/user-attachments/assets/7c5d5461-95d9-40b4-9b5c-e03e6efd56bb" />


## Assumptions we got wrong on the way here

I think this is worth writing down, because most of them looked convincing to me at the time. These are ALL WRONG:

🚫 **It was a mime type problem.** posit-dev/positron#13106 reports `Can't handle mime type "application/vnd.vegalite.v5+json" yet`, which sent us looking at output mime types. The kernel stopped sending that type in 79280dc, before v0.1.6, so no current version could produce that error. The old symptom did have a real cause worth recording in that Positron's notebook editor ranks any `application/*` mime type above `text/html`, so the Vega-Lite entry always won the selection and then had no renderer.

🚫 **It only affected untitled notebooks.** It affected saved ones too, it turns out. Untitled turned out to be irrelevant. Positron handles untitled webview outputs correctly, and probes using plotly and raw scripted HTML both rendered fine in an untitled notebook.

🚫 **The kernel was picking the wrong HTML template.** The kernel chooses a template by string-matching the Jupyter session id, which is fragile enough to be a good suspect. The saved `.ipynb` showed the correct notebook template, so this was not it. The fragility is still real, just not the cause here.

🚫 **Container sizing alone explained it.** A small container-sized spec rendered fine. The collapse needs the zero first measurement as well.

🚫 **The first version of this fix worked.** It used `view.resize().run()` behind a `clientWidth` guard. An automated code review I triggered pointed out that `resize()` never re-reads `containerSize()`, and a browser test confirmed it. The same test showed the guard was wrong too! The container reported 38px while the view had already rendered at zero, so the recovery never even armed.

That last one also produced a false positive in my manual testing. The fix appeared to work, but Positron was still running an older kernel binary from the installed kernelspec. Setting `ggsql.kernelPath` adds a runtime to the list; it does not override a selection Positron already remembers for the workspace. Anyone validating a local kernel build should confirm which binary is live first:

```sh
ps -eo pid,command | grep "ggsql-jupyter -f" | grep -v grep
```

## Testing

- 23 unit tests pass. Three of them pin the corrected behaviour specifically, including `assert!(!html.contains("view.resize()"))` so this regression cannot come back quietly.
- Browser test: generated HTML from the real template into a page whose container starts at 0px and gains width shortly after. Result is a 562x400 SVG with 13 mark elements. The unfixed code and the `view.resize()` version both produce width 0.
- Manual: cold kernel start and notebook reopen both render on the first try, verified against the correct binary this time. Console plots still land in the Plots pane and still resize with it.