### PR TITLE
Fix missing feature gates

### DIFF
--- a/src/plot/layer/geom/density.rs
+++ b/src/plot/layer/geom/density.rs
@@ -605,11 +605,14 @@ fn compute_density(
 mod tests {
     use super::*;
     use crate::plot::Parameters;
+    #[cfg(feature = "duckdb")]
     use crate::reader::duckdb::DuckDBReader;
     use crate::reader::AnsiDialect;
+    #[cfg(feature = "duckdb")]
     use crate::reader::Reader;
     use arrow::array::Array;
 
+    #[cfg(feature = "duckdb")]
     #[test]
     fn test_density_sql_no_groups() {
         let query = "SELECT x FROM (VALUES (1.0), (2.0), (3.0)) AS t(x)";
@@ -686,6 +689,7 @@ mod tests {
         assert_eq!(df.height(), 512); // 512 grid points
     }
 
+    #[cfg(feature = "duckdb")]
     #[test]
     fn test_density_sql_with_two_groups() {
         let query = "SELECT x, region, category FROM (VALUES (1.0, 'A', 'X'), (2.0, 'B', 'Y')) AS t(x, region, category)";
@@ -807,6 +811,7 @@ mod tests {
         );
     }
 
+    #[cfg(feature = "duckdb")]
     #[test]
     fn test_density_sql_computed_bandwidth() {
         // Test 1: No groups
@@ -865,6 +870,7 @@ mod tests {
     }
 
     /// Helper function to test that a kernel integrates to 1
+    #[cfg(feature = "duckdb")]
     fn test_kernel_integration(kernel_name: &str, tolerance: f64) {
         let query = "SELECT x FROM (VALUES (1.0), (2.0), (3.0), (4.0), (5.0)) AS t(x)";
         let groups: Vec<String> = vec![];
@@ -941,6 +947,7 @@ mod tests {
         );
     }
 
+    #[cfg(feature = "duckdb")]
     #[test]
     fn test_all_kernels_integrate_to_one() {
         let kernels = vec![
@@ -982,6 +989,7 @@ mod tests {
         }
     }
 
+    #[cfg(feature = "duckdb")]
     #[test]
     fn test_weighted_vs_unweighted_density() {
         // Compare weighted and unweighted results
@@ -1060,6 +1068,7 @@ mod tests {
         }
     }
 
+    #[cfg(feature = "duckdb")]
     #[test]
     fn test_density_with_intensity_remapping() {
         use crate::reader::duckdb::DuckDBReader;
@@ -1127,6 +1136,7 @@ mod tests {
         println!("✓ Successfully used REMAPPING to map y to intensity instead of density");
     }
 
+    #[cfg(feature = "duckdb")]
     #[test]
     #[ignore] // Run with: cargo test bench_density_performance -- --ignored --nocapture
     fn bench_density_performance() {

--- a/src/plot/layer/geom/smooth.rs
+++ b/src/plot/layer/geom/smooth.rs
@@ -286,9 +286,12 @@ fn stat_tls(
 mod tests {
     use super::*;
     use crate::plot::AestheticValue;
+    #[cfg(feature = "duckdb")]
     use crate::reader::duckdb::DuckDBReader;
+    #[cfg(feature = "duckdb")]
     use crate::reader::Reader;
 
+    #[cfg(feature = "duckdb")]
     #[test]
     fn test_stat_ols_ungrouped() {
         let reader = DuckDBReader::from_connection_string("duckdb://memory").unwrap();
@@ -338,6 +341,7 @@ mod tests {
         }
     }
 
+    #[cfg(feature = "duckdb")]
     #[test]
     fn test_stat_ols_grouped() {
         let reader = DuckDBReader::from_connection_string("duckdb://memory").unwrap();
@@ -390,6 +394,7 @@ mod tests {
         }
     }
 
+    #[cfg(feature = "duckdb")]
     #[test]
     fn test_stat_tls_ungrouped() {
         let reader = DuckDBReader::from_connection_string("duckdb://memory").unwrap();
@@ -439,6 +444,7 @@ mod tests {
         }
     }
 
+    #[cfg(feature = "duckdb")]
     #[test]
     fn test_stat_tls_grouped() {
         let reader = DuckDBReader::from_connection_string("duckdb://memory").unwrap();

--- a/src/plot/layer/geom/violin.rs
+++ b/src/plot/layer/geom/violin.rs
@@ -280,8 +280,10 @@ mod tests {
     use super::*;
     use crate::plot::AestheticValue;
     use crate::plot::Parameters;
+    #[cfg(feature = "duckdb")]
     use crate::reader::duckdb::DuckDBReader;
     use crate::reader::AnsiDialect;
+    #[cfg(feature = "duckdb")]
     use crate::reader::Reader;
     use arrow::array::Array;
 
@@ -323,6 +325,7 @@ mod tests {
 
     // ==================== Basic Behavior Tests ====================
 
+    #[cfg(feature = "duckdb")]
     #[test]
     fn test_violin_no_extra_groups() {
         // Test violin with just x and y (no additional grouping variables)
@@ -387,6 +390,7 @@ mod tests {
         }
     }
 
+    #[cfg(feature = "duckdb")]
     #[test]
     fn test_violin_with_extra_groups() {
         // Test violin with x, y, and an additional color grouping variable
@@ -484,6 +488,7 @@ mod tests {
         }
     }
 
+    #[cfg(feature = "duckdb")]
     #[test]
     fn test_violin_tails_parameter() {
         // Verify that the violin geom has a tails parameter with default 3.0
@@ -624,6 +629,7 @@ mod tests {
         assert!((values[2] - 0.3).abs() < 1e-6, "1.0 should become 0.3");
     }
 
+    #[cfg(feature = "duckdb")]
     #[test]
     fn test_violin_dummy_pos1_when_unmapped() {
         // pos2 only - pos1 omitted should produce a single violin via dummy x.

--- a/src/plot/projection/coord/map.rs
+++ b/src/plot/projection/coord/map.rs
@@ -1265,8 +1265,8 @@ mod tests {
         Err(crate::GgsqlError::InternalError("no db".into()))
     }
 
-    fn noop_dialect() -> crate::reader::duckdb::DuckDbDialect {
-        crate::reader::duckdb::DuckDbDialect
+    fn noop_dialect() -> crate::reader::AnsiDialect {
+        crate::reader::AnsiDialect
     }
 
     mod scale_override_bbox_tests {

--- a/src/reader/data.rs
+++ b/src/reader/data.rs
@@ -214,6 +214,7 @@ mod duckdb_tests {
         );
     }
 
+    #[cfg(feature = "vegalite")]
     #[test]
     fn test_ribbon_transposed_vegalite_encoding() {
         use crate::reader::Reader;

--- a/src/reader/mod.rs
+++ b/src/reader/mod.rs
@@ -1637,6 +1637,7 @@ mod tests {
         );
     }
 
+    #[cfg(feature = "builtin-data")]
     #[test]
     fn test_stacked_bar_chart_dummy_x() {
         // Test stacked bar chart with no x mapping (dummy x column)
@@ -1671,6 +1672,7 @@ mod tests {
         );
     }
 
+    #[cfg(feature = "builtin-data")]
     #[test]
     fn test_boxplot_dummy_x() {
         // Boxplot with only y mapped: should render a single boxplot of the
@@ -1697,6 +1699,7 @@ mod tests {
         );
     }
 
+    #[cfg(feature = "builtin-data")]
     #[test]
     fn test_violin_dummy_x() {
         // Violin with only y mapped: single violin spanning the whole dataset.
@@ -1720,6 +1723,7 @@ mod tests {
         );
     }
 
+    #[cfg(feature = "builtin-data")]
     #[test]
     fn test_point_dummy_x() {
         // Point with only y mapped: strip plot at a single dummy x position.
@@ -1767,6 +1771,7 @@ mod tests {
         );
     }
 
+    #[cfg(feature = "builtin-data")]
     #[test]
     fn test_point_dummy_y() {
         // Symmetric to test_point_dummy_x: only x mapped means dummy y.
@@ -1790,6 +1795,7 @@ mod tests {
         );
     }
 
+    #[cfg(feature = "builtin-data")]
     #[test]
     fn test_point_dummy_both_with_aggregate() {
         // Both axes omitted, but aggregate gives the single point meaning:
@@ -1820,6 +1826,7 @@ mod tests {
         );
     }
 
+    #[cfg(feature = "builtin-data")]
     #[test]
     fn test_point_dummy_x_with_aggregate() {
         // Point with aggregate SETTING and no x mapping: should aggregate the
@@ -1845,6 +1852,7 @@ mod tests {
         );
     }
 
+    #[cfg(feature = "builtin-data")]
     #[test]
     fn test_bar_chart_with_expand_setting() {
         // Test bar chart with SCALE y SETTING expand - should work even when y is stat-derived

--- a/src/reader/sqlite.rs
+++ b/src/reader/sqlite.rs
@@ -819,6 +819,7 @@ mod tests {
         assert_eq!(df.column_dtype("y").unwrap(), DataType::Int64);
     }
 
+    #[cfg(feature = "vegalite")]
     #[test]
     fn test_subquery_vegalite_quantitative() {
         use crate::writer::{VegaLiteWriter, Writer};
@@ -1213,6 +1214,7 @@ mod tests {
         assert_eq!(result.column_dtype("name").unwrap(), DataType::Utf8);
     }
 
+    #[cfg(feature = "vegalite")]
     #[test]
     fn test_date_vegalite_temporal() {
         use crate::writer::{VegaLiteWriter, Writer};

--- a/src/writer/hephaestus/mod.rs
+++ b/src/writer/hephaestus/mod.rs
@@ -1012,6 +1012,7 @@ mod tests {
         ));
     }
 
+    #[cfg(feature = "builtin-data")]
     #[test]
     fn renders_free_binned_facet() {
         // A free binned position dimension: each panel keeps ggsql's global bin
@@ -1023,6 +1024,7 @@ mod tests {
         );
     }
 
+    #[cfg(feature = "builtin-data")]
     #[test]
     fn renders_binned_size_legend() {
         // A binned *keyed* legend: one key per bin, sized at the bin's midpoint,
@@ -1034,6 +1036,7 @@ mod tests {
         );
     }
 
+    #[cfg(feature = "builtin-data")]
     #[test]
     fn renders_binned_color_legend() {
         // The same ladder driving color: a stepped colorbar, one block per bin.
@@ -1110,6 +1113,7 @@ mod tests {
         );
     }
 
+    #[cfg(feature = "builtin-data")]
     #[test]
     fn renders_jittered_points() {
         // `position => 'jitter'` spreads the points across their category band;
@@ -1147,6 +1151,7 @@ mod tests {
         );
     }
 
+    #[cfg(feature = "builtin-data")]
     #[test]
     fn renders_jitter_with_half_boxplot() {
         // The documented raincloud layout: a one-sided jitter above the
@@ -1385,6 +1390,7 @@ mod svg_text {
         }
     }
 
+    #[cfg(feature = "builtin-data")]
     #[test]
     fn a_binned_scales_edge_labels_reach_the_legend() {
         // The renderer cannot derive a bin ladder, so all five edges appearing

--- a/src/writer/vegalite/layer.rs
+++ b/src/writer/vegalite/layer.rs
@@ -3142,6 +3142,7 @@ mod tests {
         }
     }
 
+    #[cfg(feature = "duckdb")]
     #[test]
     fn test_text_angle_integration() {
         use crate::execute;
@@ -3260,6 +3261,7 @@ mod tests {
         }
     }
 
+    #[cfg(feature = "duckdb")]
     #[test]
     fn test_text_offset_parameters() {
         use crate::execute;
@@ -3327,6 +3329,7 @@ mod tests {
         }
     }
 
+    #[cfg(feature = "duckdb")]
     #[test]
     fn test_text_label_formatting() {
         use crate::execute;
@@ -3384,6 +3387,7 @@ mod tests {
         assert!(labels.contains(&"Region: East Region"));
     }
 
+    #[cfg(feature = "duckdb")]
     #[test]
     fn test_text_label_formatting_numeric() {
         use crate::execute;
@@ -3427,6 +3431,7 @@ mod tests {
         assert!(labels.contains(&"$21.00"));
     }
 
+    #[cfg(feature = "duckdb")]
     #[test]
     fn test_text_label_newline_splitting() {
         use crate::execute;
@@ -3502,6 +3507,7 @@ mod tests {
         assert_eq!(annotation_lines[1].as_str().unwrap(), "With Newline");
     }
 
+    #[cfg(feature = "duckdb")]
     #[test]
     fn test_text_setting_fontweight() {
         use crate::execute;
@@ -3559,6 +3565,7 @@ mod tests {
         }
     }
 
+    #[cfg(feature = "duckdb")]
     #[test]
     fn test_text_setting_fontweight_numeric() {
         use crate::execute;
@@ -3597,6 +3604,7 @@ mod tests {
         }
     }
 
+    #[cfg(feature = "duckdb")]
     #[test]
     fn test_text_setting_fontweight_numeric_normal() {
         use crate::execute;
@@ -3635,6 +3643,7 @@ mod tests {
         }
     }
 
+    #[cfg(feature = "duckdb")]
     #[test]
     fn test_text_setting_fontweight_keywords() {
         use crate::execute;
@@ -4378,6 +4387,7 @@ mod tests {
             .contains("no valid numeric range"));
     }
 
+    #[cfg(feature = "duckdb")]
     #[test]
     fn test_rule_renderer_multiple_diagonal_lines() {
         use crate::reader::{DuckDBReader, Reader};
@@ -4560,6 +4570,7 @@ mod tests {
         );
     }
 
+    #[cfg(feature = "duckdb")]
     #[test]
     fn test_sloped_rule_renderer_horizontal_orientation() {
         use crate::reader::{DuckDBReader, Reader};

--- a/src/writer/vegalite/mod.rs
+++ b/src/writer/vegalite/mod.rs
@@ -1562,6 +1562,7 @@ mod tests {
         assert_eq!(vl_spec["layer"][0]["mark"]["clip"], true);
     }
 
+    #[cfg(feature = "duckdb")]
     #[test]
     fn test_labels_newline_splitting() {
         use crate::execute;

--- a/src/writer/vegalite/projection/map.rs
+++ b/src/writer/vegalite/projection/map.rs
@@ -248,6 +248,7 @@ mod tests {
         assert_eq!(layers[0]["mark"]["stroke"], "gray");
     }
 
+    #[cfg(feature = "spatial")]
     #[test]
     fn test_background_layer_with_boundary() {
         let mut proj = Projection::map();
@@ -301,6 +302,7 @@ mod tests {
         assert!(translate.as_str().unwrap().contains("height"));
     }
 
+    #[cfg(feature = "spatial")]
     #[test]
     fn test_graticule_layers_rendered() {
         let mut proj = Projection::map();
@@ -331,6 +333,7 @@ mod tests {
         }
     }
 
+    #[cfg(feature = "spatial")]
     #[test]
     fn test_graticule_with_panel_boundary() {
         let mut proj = Projection::map();


### PR DESCRIPTION
Stumbled on a small part of this in unrelated work, decided to tackle this first, which then blew up to a whole bunch of tests that didn't have the feature gates sets correctly. Mostly discovered through `--no-default-features` + particular combinations of features.