### PR TITLE
Drop the smctl flag the pinned build does not support

### DIFF
--- a/.github/workflows/actions/sign-files/action.yml
+++ b/.github/workflows/actions/sign-files/action.yml
@@ -121,7 +121,9 @@ runs:
         }
         foreach ($path in $paths) {
           Write-Output "::group::Signing ${path}"
-          smctl sign --keypair-alias $env:SM_KEYPAIR_ALIAS --input $path --digalg SHA256 --sigalg SHA256 --timestamp=true --verbose --exit-non-zero-on-fail
+          # The pinned smctl build exits 0 even when signing fails and lacks
+          # --exit-non-zero-on-fail; the verify steps below are the failure gate.
+          smctl sign --keypair-alias $env:SM_KEYPAIR_ALIAS --input $path --digalg SHA256 --sigalg SHA256 --timestamp=true --verbose
           if ($LASTEXITCODE -ne 0) {
             Write-Output "::error title=Signing error::Error while signing ${path}"
             exit 1


### PR DESCRIPTION
The pinned smtools MSI ships an smctl without --exit-non-zero-on-fail, so every `smctl sign` invocation failed immediately with `unknown flag: --exit-non-zero-on-fail`.

That build also exits 0 when signing fails, so the signtool verify and Get-AuthenticodeSignature checks are what gate the step.